### PR TITLE
Use JobIdentifier Information provided as part of elastic agent extension V2

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagent/Constants.java
+++ b/src/main/java/cd/go/contrib/elasticagent/Constants.java
@@ -46,7 +46,6 @@ public interface Constants {
     String CREATED_BY_LABEL_KEY = "Elastic-Agent-Created-By";
     String ENVIRONMENT_LABEL_KEY = "Elastic-Agent-Environment-Name";
     String JOB_ID_LABEL_KEY = "Elastic-Agent-Job-Identifier";
-    String JOB_NAME_LABEL_KEY = "Elastic-Agent-Job-Name";
 
     String KUBERNETES_NAMESPACE_KEY = "default";
     String KUBERNETES_POD_KIND_LABEL_KEY = "kind";

--- a/src/main/java/cd/go/contrib/elasticagent/Constants.java
+++ b/src/main/java/cd/go/contrib/elasticagent/Constants.java
@@ -45,6 +45,9 @@ public interface Constants {
     // internal use only
     String CREATED_BY_LABEL_KEY = "Elastic-Agent-Created-By";
     String ENVIRONMENT_LABEL_KEY = "Elastic-Agent-Environment-Name";
+    String JOB_ID_LABEL_KEY = "Elastic-Agent-Job-Identifier";
+    String JOB_NAME_LABEL_KEY = "Elastic-Agent-Job-Name";
+
     String KUBERNETES_NAMESPACE_KEY = "default";
     String KUBERNETES_POD_KIND_LABEL_KEY = "kind";
     String KUBERNETES_POD_KIND_LABEL_VALUE = "kubernetes-elastic-agent";

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstance.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstance.java
@@ -16,175 +16,27 @@
 
 package cd.go.contrib.elasticagent;
 
-import cd.go.contrib.elasticagent.requests.CreateAgentRequest;
-import cd.go.contrib.elasticagent.utils.Size;
-import cd.go.contrib.elasticagent.utils.Util;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.github.mustachejava.DefaultMustacheFactory;
-import com.github.mustachejava.Mustache;
-import com.github.mustachejava.MustacheFactory;
-import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.*;
-
-import static cd.go.contrib.elasticagent.Constants.KUBERNETES_POD_CREATION_TIME_FORMAT;
-import static cd.go.contrib.elasticagent.KubernetesPlugin.LOG;
-import static cd.go.contrib.elasticagent.executors.GetProfileMetadataExecutor.POD_CONFIGURATION;
-import static cd.go.contrib.elasticagent.utils.Util.getSimpleDateFormat;
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import java.util.Map;
 
 public class KubernetesInstance {
     private final DateTime createdAt;
     private final String environment;
+    private final String name;
     private final Map<String, String> properties;
-    private String name;
 
-    private KubernetesInstance(String name, Date createdAt, String environment, Map<String, String> properties) {
-        this.name = name;
-        this.createdAt = new DateTime(createdAt).withZone(DateTimeZone.UTC);
+    public KubernetesInstance(DateTime createdAt, String environment, String name, Map<String, String> properties) {
+        this.createdAt = createdAt.withZone(DateTimeZone.UTC);
         this.environment = environment;
+        this.name = name;
         this.properties = properties;
     }
 
-    public static KubernetesInstance create(CreateAgentRequest request, PluginSettings settings, KubernetesClient client, PluginRequest pluginRequest) {
-        String containerName = Constants.KUBERNETES_POD_NAME + UUID.randomUUID().toString();
-
-        Container container = new Container();
-        container.setName(containerName);
-        container.setImage(image(request.properties()));
-        container.setImagePullPolicy("IfNotPresent");
-
-        ResourceRequirements resources = new ResourceRequirements();
-        resources.setLimits(new HashMap<String, Quantity>() {{
-            String maxMemory = request.properties().get("MaxMemory");
-            if (StringUtils.isNotBlank(maxMemory)) {
-                LOG.debug(String.format("[Create Agent] Setting memory resource limit on k8s pod:%s", maxMemory));
-                Size mem = Size.parse(maxMemory);
-                put("memory", new Quantity(String.valueOf(mem.toMegabytes()), "Mi"));
-            }
-
-            String maxCPU = request.properties().get("MaxCPU");
-            if (StringUtils.isNotBlank(maxCPU)) {
-                LOG.debug(String.format("[Create Agent] Setting cpu resource limit on k8s pod:%s", maxCPU));
-                put("cpu", new Quantity(maxCPU));
-            }
-        }});
-        container.setResources(resources);
-
-        ObjectMeta podMetadata = new ObjectMeta();
-        podMetadata.setName(containerName);
-
-        PodSpec podSpec = new PodSpec();
-        podSpec.setContainers(Arrays.asList(container));
-
-        Pod elasticAgentPod = new Pod("v1", "Pod", podMetadata, podSpec, new PodStatus());
-
-        setContainerEnvVariables(elasticAgentPod, request, settings, pluginRequest);
-        setAnnotations(elasticAgentPod, request);
-        setLabels(elasticAgentPod, request);
-
-        return createKubernetesPod(client, elasticAgentPod);
-    }
-
-    private static void setLabels(Pod pod, CreateAgentRequest request) {
-        Map<String, String> existingLabels = (pod.getMetadata().getLabels() != null) ? pod.getMetadata().getLabels() : new HashMap<>();
-        existingLabels.putAll(labelsFrom(request));
-        pod.getMetadata().setLabels(existingLabels);
-    }
-
-    private static void setAnnotations(Pod pod, CreateAgentRequest request) {
-        Map<String, String> existingAnnotations = (pod.getMetadata().getAnnotations() != null) ? pod.getMetadata().getAnnotations() : new HashMap<>();
-        existingAnnotations.putAll(request.properties());
-        pod.getMetadata().setAnnotations(existingAnnotations);
-    }
-
-    private static KubernetesInstance createKubernetesPod(KubernetesClient client, Pod elasticAgentPod) {
-        LOG.info(String.format("[Create Agent] Creating K8s pod with spec:%s", elasticAgentPod.toString()));
-        client.pods().inNamespace(Constants.KUBERNETES_NAMESPACE_KEY).create(elasticAgentPod);
-        return fromInstanceInfo(elasticAgentPod);
-    }
-
-    static KubernetesInstance fromInstanceInfo(Pod elasticAgentPod) {
-        try {
-            ObjectMeta metadata = elasticAgentPod.getMetadata();
-            String containerName = metadata.getName();
-            String environment = metadata.getLabels().get(Constants.ENVIRONMENT_LABEL_KEY);
-
-            Date date = new Date();
-            if(StringUtils.isNotBlank(metadata.getCreationTimestamp())) {
-                date = getSimpleDateFormat().parse(metadata.getCreationTimestamp());
-            }
-            return new KubernetesInstance(containerName, date, environment, metadata.getAnnotations());
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static List<EnvVar> environmentFrom(CreateAgentRequest request, PluginSettings settings, String podName, PluginRequest pluginRequest) {
-        ArrayList<EnvVar> env = new ArrayList<>();
-        String goServerUrl = StringUtils.isBlank(settings.getGoServerUrl()) ? pluginRequest.getSeverInfo().getSecureSiteUrl() : settings.getGoServerUrl();
-        env.add(new EnvVar("GO_EA_SERVER_URL", goServerUrl, null));
-        String environment = request.properties().get("Environment");
-        if (StringUtils.isNotBlank(environment)) {
-            env.addAll(parseEnvironments(environment));
-        }
-        env.addAll(request.autoregisterPropertiesAsEnvironmentVars(podName));
-
-        return new ArrayList<>(env);
-    }
-
-    private static void setContainerEnvVariables(Pod pod, CreateAgentRequest request, PluginSettings settings, PluginRequest pluginRequest) {
-        for (Container container : pod.getSpec().getContainers()) {
-            List<EnvVar> existingEnv = (container.getEnv() != null) ? container.getEnv() : new ArrayList<>();
-            existingEnv.addAll(environmentFrom(request, settings, pod.getMetadata().getName(), pluginRequest));
-            container.setEnv(existingEnv);
-        }
-    }
-
-    private static Collection<? extends EnvVar> parseEnvironments(String environment) {
-        ArrayList<EnvVar> envVars = new ArrayList<>();
-        for (String env : environment.split("\n")) {
-            String[] parts = env.split("=");
-            envVars.add(new EnvVar(parts[0], parts[1], null));
-        }
-
-        return envVars;
-    }
-
-    private static HashMap<String, String> labelsFrom(CreateAgentRequest request) {
-        HashMap<String, String> labels = new HashMap<>();
-
-        labels.put(Constants.CREATED_BY_LABEL_KEY, Constants.PLUGIN_ID);
-        if (StringUtils.isNotBlank(request.environment())) {
-            labels.put(Constants.ENVIRONMENT_LABEL_KEY, request.environment());
-        }
-
-        labels.put(Constants.KUBERNETES_POD_KIND_LABEL_KEY, Constants.KUBERNETES_POD_KIND_LABEL_VALUE);
-
-        return labels;
-    }
-
-    private static String image(Map<String, String> properties) {
-        String image = properties.get("Image");
-
-        if (isBlank(image)) {
-            throw new IllegalArgumentException("Must provide `Image` attribute.");
-        }
-
-        if (!image.contains(":")) {
-            return image + ":latest";
-        }
-        return image;
+    public void terminate(KubernetesClient client) {
+        client.pods().inNamespace(Constants.KUBERNETES_NAMESPACE_KEY).withName(name).delete();
     }
 
     public String name() {
@@ -199,62 +51,7 @@ public class KubernetesInstance {
         return environment;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        KubernetesInstance that = (KubernetesInstance) o;
-
-        return name != null ? name.equals(that.name) : that.name == null;
-    }
-
-    @Override
-    public int hashCode() {
-        return name != null ? name.hashCode() : 0;
-    }
-
-    public void terminate(KubernetesClient client) {
-        client.pods().inNamespace(Constants.KUBERNETES_NAMESPACE_KEY).withName(name).delete();
-    }
-
     public Map<String, String> getInstanceProperties() {
         return properties;
-    }
-
-    public static KubernetesInstance createUsingPodYaml(CreateAgentRequest request, PluginSettings settings, KubernetesClient client, PluginRequest pluginRequest) {
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        String podYaml = request.properties().get(POD_CONFIGURATION.getKey());
-
-        StringWriter writer = new StringWriter();
-        MustacheFactory mf = new DefaultMustacheFactory();
-        Mustache mustache = mf.compile(new StringReader(podYaml), "templatePod");
-        mustache.execute(writer, KubernetesInstance.getJinJavaContext());
-        String templatizedPodYaml = writer.toString();
-
-        Pod elasticAgentPod = new Pod();
-        try {
-            elasticAgentPod = mapper.readValue(templatizedPodYaml, Pod.class);
-        } catch (IOException e) {
-            //ignore error here, handle this inside validate profile!
-            e.printStackTrace();
-        }
-
-        elasticAgentPod.getMetadata().setCreationTimestamp(getSimpleDateFormat().format(new Date()));
-
-        setContainerEnvVariables(elasticAgentPod, request, settings, pluginRequest);
-        setAnnotations(elasticAgentPod, request);
-        setLabels(elasticAgentPod, request);
-
-        return createKubernetesPod(client, elasticAgentPod);
-    }
-
-    public static Map<String, String> getJinJavaContext() {
-        HashMap<String, String> context = new HashMap<>();
-        context.put(Constants.POD_POSTFIX, UUID.randomUUID().toString());
-        context.put(Constants.CONTAINER_POSTFIX, UUID.randomUUID().toString());
-        context.put(Constants.GOCD_AGENT_IMAGE, "gocd/gocd-agent-alpine-3.5");
-        context.put(Constants.LATEST_VERSION, "v17.10.0");
-        return context;
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstance.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstance.java
@@ -27,12 +27,14 @@ public class KubernetesInstance {
     private final String environment;
     private final String name;
     private final Map<String, String> properties;
+    private final Long jobId;
 
-    public KubernetesInstance(DateTime createdAt, String environment, String name, Map<String, String> properties) {
+    public KubernetesInstance(DateTime createdAt, String environment, String name, Map<String, String> properties, Long jobId) {
         this.createdAt = createdAt.withZone(DateTimeZone.UTC);
         this.environment = environment;
         this.name = name;
         this.properties = properties;
+        this.jobId = jobId;
     }
 
     public void terminate(KubernetesClient client) {

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstance.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstance.java
@@ -56,4 +56,8 @@ public class KubernetesInstance {
     public Map<String, String> getInstanceProperties() {
         return properties;
     }
+
+    public Long jobId() {
+        return jobId;
+    }
 }

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
@@ -159,6 +159,9 @@ public class KubernetesInstanceFactory {
         HashMap<String, String> labels = new HashMap<>();
 
         labels.put(Constants.CREATED_BY_LABEL_KEY, Constants.PLUGIN_ID);
+        labels.put(Constants.JOB_ID_LABEL_KEY, String.valueOf(request.jobIdentifier().getJobId()));
+        labels.put(Constants.JOB_NAME_LABEL_KEY, request.jobIdentifier().getJobName());
+
         if (StringUtils.isNotBlank(request.environment())) {
             labels.put(Constants.ENVIRONMENT_LABEL_KEY, request.environment());
         }

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
@@ -160,7 +160,6 @@ public class KubernetesInstanceFactory {
 
         labels.put(Constants.CREATED_BY_LABEL_KEY, Constants.PLUGIN_ID);
         labels.put(Constants.JOB_ID_LABEL_KEY, String.valueOf(request.jobIdentifier().getJobId()));
-        labels.put(Constants.JOB_NAME_LABEL_KEY, request.jobIdentifier().getJobName());
 
         if (StringUtils.isNotBlank(request.environment())) {
             labels.put(Constants.ENVIRONMENT_LABEL_KEY, request.environment());

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.contrib.elasticagent;
+
+import cd.go.contrib.elasticagent.requests.CreateAgentRequest;
+import cd.go.contrib.elasticagent.utils.Size;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.text.ParseException;
+import java.util.*;
+
+import static cd.go.contrib.elasticagent.KubernetesPlugin.LOG;
+import static cd.go.contrib.elasticagent.executors.GetProfileMetadataExecutor.POD_CONFIGURATION;
+import static cd.go.contrib.elasticagent.utils.Util.getSimpleDateFormat;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class KubernetesInstanceFactory {
+    public KubernetesInstance create(CreateAgentRequest request, PluginSettings settings, KubernetesClient client, PluginRequest pluginRequest, Boolean usesPodYaml) {
+        if (usesPodYaml) {
+            return createUsingPodYaml(request, settings, client, pluginRequest);
+        } else {
+            return create(request, settings, client, pluginRequest);
+        }
+    }
+
+    private KubernetesInstance create(CreateAgentRequest request, PluginSettings settings, KubernetesClient client, PluginRequest pluginRequest) {
+        String containerName = Constants.KUBERNETES_POD_NAME + UUID.randomUUID().toString();
+
+        Container container = new Container();
+        container.setName(containerName);
+        container.setImage(image(request.properties()));
+        container.setImagePullPolicy("IfNotPresent");
+
+        ResourceRequirements resources = new ResourceRequirements();
+        resources.setLimits(new HashMap<String, Quantity>() {{
+            String maxMemory = request.properties().get("MaxMemory");
+            if (StringUtils.isNotBlank(maxMemory)) {
+                LOG.debug(String.format("[Create Agent] Setting memory resource limit on k8s pod:%s", maxMemory));
+                Size mem = Size.parse(maxMemory);
+                put("memory", new Quantity(String.valueOf(mem.toMegabytes()), "Mi"));
+            }
+
+            String maxCPU = request.properties().get("MaxCPU");
+            if (StringUtils.isNotBlank(maxCPU)) {
+                LOG.debug(String.format("[Create Agent] Setting cpu resource limit on k8s pod:%s", maxCPU));
+                put("cpu", new Quantity(maxCPU));
+            }
+        }});
+
+        container.setResources(resources);
+
+        ObjectMeta podMetadata = new ObjectMeta();
+        podMetadata.setName(containerName);
+
+        PodSpec podSpec = new PodSpec();
+        podSpec.setContainers(Arrays.asList(container));
+
+        Pod elasticAgentPod = new Pod("v1", "Pod", podMetadata, podSpec, new PodStatus());
+
+        setContainerEnvVariables(elasticAgentPod, request, settings, pluginRequest);
+        setAnnotations(elasticAgentPod, request);
+        setLabels(elasticAgentPod, request);
+
+        return createKubernetesPod(client, elasticAgentPod);
+    }
+
+    private static void setLabels(Pod pod, CreateAgentRequest request) {
+        Map<String, String> existingLabels = (pod.getMetadata().getLabels() != null) ? pod.getMetadata().getLabels() : new HashMap<>();
+        existingLabels.putAll(labelsFrom(request));
+        pod.getMetadata().setLabels(existingLabels);
+    }
+
+    private static void setAnnotations(Pod pod, CreateAgentRequest request) {
+        Map<String, String> existingAnnotations = (pod.getMetadata().getAnnotations() != null) ? pod.getMetadata().getAnnotations() : new HashMap<>();
+        existingAnnotations.putAll(request.properties());
+        pod.getMetadata().setAnnotations(existingAnnotations);
+    }
+
+    private KubernetesInstance createKubernetesPod(KubernetesClient client, Pod elasticAgentPod) {
+        LOG.info(String.format("[Create Agent] Creating K8s pod with spec:%s", elasticAgentPod.toString()));
+        client.pods().inNamespace(Constants.KUBERNETES_NAMESPACE_KEY).create(elasticAgentPod);
+        return fromKubernetesPod(elasticAgentPod);
+    }
+
+    public KubernetesInstance fromKubernetesPod(Pod elasticAgentPod) {
+        KubernetesInstance kubernetesInstance;
+        try {
+            ObjectMeta metadata = elasticAgentPod.getMetadata();
+            DateTime createdAt = DateTime.now().withZone(DateTimeZone.UTC);
+            if (StringUtils.isNotBlank(metadata.getCreationTimestamp())) {
+                createdAt = new DateTime(getSimpleDateFormat().parse(metadata.getCreationTimestamp())).withZone(DateTimeZone.UTC);
+            }
+            String environment = metadata.getLabels().get(Constants.ENVIRONMENT_LABEL_KEY);
+            kubernetesInstance = new KubernetesInstance(createdAt, environment, metadata.getName(), metadata.getAnnotations());
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+        return kubernetesInstance;
+    }
+
+    private static List<EnvVar> environmentFrom(CreateAgentRequest request, PluginSettings settings, String podName, PluginRequest pluginRequest) {
+        ArrayList<EnvVar> env = new ArrayList<>();
+        String goServerUrl = StringUtils.isBlank(settings.getGoServerUrl()) ? pluginRequest.getSeverInfo().getSecureSiteUrl() : settings.getGoServerUrl();
+        env.add(new EnvVar("GO_EA_SERVER_URL", goServerUrl, null));
+        String environment = request.properties().get("Environment");
+        if (StringUtils.isNotBlank(environment)) {
+            env.addAll(parseEnvironments(environment));
+        }
+        env.addAll(request.autoregisterPropertiesAsEnvironmentVars(podName));
+
+        return new ArrayList<>(env);
+    }
+
+    private static void setContainerEnvVariables(Pod pod, CreateAgentRequest request, PluginSettings settings, PluginRequest pluginRequest) {
+        for (Container container : pod.getSpec().getContainers()) {
+            List<EnvVar> existingEnv = (container.getEnv() != null) ? container.getEnv() : new ArrayList<>();
+            existingEnv.addAll(environmentFrom(request, settings, pod.getMetadata().getName(), pluginRequest));
+            container.setEnv(existingEnv);
+        }
+    }
+
+    private static Collection<? extends EnvVar> parseEnvironments(String environment) {
+        ArrayList<EnvVar> envVars = new ArrayList<>();
+        for (String env : environment.split("\n")) {
+            String[] parts = env.split("=");
+            envVars.add(new EnvVar(parts[0], parts[1], null));
+        }
+
+        return envVars;
+    }
+
+    private static HashMap<String, String> labelsFrom(CreateAgentRequest request) {
+        HashMap<String, String> labels = new HashMap<>();
+
+        labels.put(Constants.CREATED_BY_LABEL_KEY, Constants.PLUGIN_ID);
+        if (StringUtils.isNotBlank(request.environment())) {
+            labels.put(Constants.ENVIRONMENT_LABEL_KEY, request.environment());
+        }
+
+        labels.put(Constants.KUBERNETES_POD_KIND_LABEL_KEY, Constants.KUBERNETES_POD_KIND_LABEL_VALUE);
+
+        return labels;
+    }
+
+    private static String image(Map<String, String> properties) {
+        String image = properties.get("Image");
+
+        if (isBlank(image)) {
+            throw new IllegalArgumentException("Must provide `Image` attribute.");
+        }
+
+        if (!image.contains(":")) {
+            return image + ":latest";
+        }
+        return image;
+    }
+
+    private KubernetesInstance createUsingPodYaml(CreateAgentRequest request, PluginSettings settings, KubernetesClient client, PluginRequest pluginRequest) {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        String podYaml = request.properties().get(POD_CONFIGURATION.getKey());
+
+        StringWriter writer = new StringWriter();
+        MustacheFactory mf = new DefaultMustacheFactory();
+        Mustache mustache = mf.compile(new StringReader(podYaml), "templatePod");
+        mustache.execute(writer, KubernetesInstanceFactory.getJinJavaContext());
+        String templatizedPodYaml = writer.toString();
+
+        Pod elasticAgentPod = new Pod();
+        try {
+            elasticAgentPod = mapper.readValue(templatizedPodYaml, Pod.class);
+        } catch (IOException e) {
+            //ignore error here, handle this inside validate profile!
+            LOG.error(e.getMessage());
+        }
+
+        elasticAgentPod.getMetadata().setCreationTimestamp(getSimpleDateFormat().format(new Date()));
+
+        setContainerEnvVariables(elasticAgentPod, request, settings, pluginRequest);
+        setAnnotations(elasticAgentPod, request);
+        setLabels(elasticAgentPod, request);
+
+        return createKubernetesPod(client, elasticAgentPod);
+    }
+
+    public static Map<String, String> getJinJavaContext() {
+        HashMap<String, String> context = new HashMap<>();
+        context.put(Constants.POD_POSTFIX, UUID.randomUUID().toString());
+        context.put(Constants.CONTAINER_POSTFIX, UUID.randomUUID().toString());
+        context.put(Constants.GOCD_AGENT_IMAGE, "gocd/gocd-agent-alpine-3.5");
+        context.put(Constants.LATEST_VERSION, "v17.10.0");
+        return context;
+    }
+}

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
@@ -117,7 +117,8 @@ public class KubernetesInstanceFactory {
                 createdAt = new DateTime(getSimpleDateFormat().parse(metadata.getCreationTimestamp())).withZone(DateTimeZone.UTC);
             }
             String environment = metadata.getLabels().get(Constants.ENVIRONMENT_LABEL_KEY);
-            kubernetesInstance = new KubernetesInstance(createdAt, environment, metadata.getName(), metadata.getAnnotations());
+            Long jobId = Long.valueOf(metadata.getLabels().get(Constants.JOB_ID_LABEL_KEY));
+            kubernetesInstance = new KubernetesInstance(createdAt, environment, metadata.getName(), metadata.getAnnotations(), jobId);
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutor.java
@@ -18,6 +18,7 @@ package cd.go.contrib.elasticagent.executors;
 
 import cd.go.contrib.elasticagent.AgentInstances;
 import cd.go.contrib.elasticagent.KubernetesInstance;
+import cd.go.contrib.elasticagent.KubernetesInstanceFactory;
 import cd.go.contrib.elasticagent.RequestExecutor;
 import cd.go.contrib.elasticagent.requests.ShouldAssignWorkRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;

--- a/src/main/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutor.java
@@ -18,17 +18,10 @@ package cd.go.contrib.elasticagent.executors;
 
 import cd.go.contrib.elasticagent.AgentInstances;
 import cd.go.contrib.elasticagent.KubernetesInstance;
-import cd.go.contrib.elasticagent.KubernetesInstanceFactory;
 import cd.go.contrib.elasticagent.RequestExecutor;
 import cd.go.contrib.elasticagent.requests.ShouldAssignWorkRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static cd.go.contrib.elasticagent.KubernetesPlugin.LOG;
-import static org.apache.commons.lang3.StringUtils.stripToEmpty;
 
 public class ShouldAssignWorkRequestExecutor implements RequestExecutor {
     private final AgentInstances<KubernetesInstance> agentInstances;
@@ -41,22 +34,13 @@ public class ShouldAssignWorkRequestExecutor implements RequestExecutor {
 
     @Override
     public GoPluginApiResponse execute() {
-        KubernetesInstance instance = agentInstances.find(request.agent().elasticAgentId());
+        KubernetesInstance pod = agentInstances.find(request.agent().elasticAgentId());
 
-        if (instance == null) {
+        if (pod == null) {
             return DefaultGoPluginApiResponse.success("false");
         }
 
-        boolean environmentMatches = stripToEmpty(request.environment()).equalsIgnoreCase(stripToEmpty(instance.environment()));
-
-
-        Map<String, String> containerProperties = instance.getInstanceProperties() == null ? new HashMap<>() : instance.getInstanceProperties();
-        Map<String, String> requestProperties = request.properties() == null ? new HashMap<>() : request.properties();
-
-        boolean propertiesMatch = requestProperties.equals(containerProperties);
-
-        if (environmentMatches && propertiesMatch) {
-            LOG.debug(String.format("[Should Assign Work] Assigning job[%s] to agent[%s]", request.properties(), request.agent().elasticAgentId()));
+        if (request.jobIdentifier().getJobId().equals(pod.jobId())) {
             return DefaultGoPluginApiResponse.success("true");
         }
 

--- a/src/main/java/cd/go/contrib/elasticagent/model/JobIdentifier.java
+++ b/src/main/java/cd/go/contrib/elasticagent/model/JobIdentifier.java
@@ -57,7 +57,11 @@ public class JobIdentifier {
         jobId = null;
     }
 
-    public JobIdentifier(String pipelineName, long pipelineCounter, String pipelineLabel, String staqeName, String stageCounter, String jobName, long jobId) {
+    public JobIdentifier(Long jobId) {
+        this(null, null, null, null, null, null, jobId);
+    }
+
+    public JobIdentifier(String pipelineName, Long pipelineCounter, String pipelineLabel, String staqeName, String stageCounter, String jobName, Long jobId) {
         this.pipelineName = pipelineName;
         this.pipelineCounter = pipelineCounter;
         this.pipelineLabel = pipelineLabel;

--- a/src/main/java/cd/go/contrib/elasticagent/model/JobIdentifier.java
+++ b/src/main/java/cd/go/contrib/elasticagent/model/JobIdentifier.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.contrib.elasticagent.model;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class JobIdentifier {
+    @Expose
+    @SerializedName("pipeline_name")
+    private String pipelineName;
+
+    @Expose
+    @SerializedName("pipeline_counter")
+    private final Long pipelineCounter;
+
+    @Expose
+    @SerializedName("pipeline_label")
+    private final String pipelineLabel;
+
+    @Expose
+    @SerializedName("stage_name")
+    private final String staqeName;
+
+    @Expose
+    @SerializedName("stage_counter")
+    private final String stageCounter;
+
+    @Expose
+    @SerializedName("job_name")
+    private final String jobName;
+
+    @Expose
+    @SerializedName("job_id")
+    private final Long jobId;
+
+    public JobIdentifier() {
+        pipelineCounter = null;
+        pipelineLabel = null;
+        staqeName = null;
+        stageCounter = null;
+        jobName = null;
+        jobId = null;
+    }
+
+    public JobIdentifier(String pipelineName, long pipelineCounter, String pipelineLabel, String staqeName, String stageCounter, String jobName, long jobId) {
+        this.pipelineName = pipelineName;
+        this.pipelineCounter = pipelineCounter;
+        this.pipelineLabel = pipelineLabel;
+        this.staqeName = staqeName;
+        this.stageCounter = stageCounter;
+        this.jobName = jobName;
+        this.jobId = jobId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof JobIdentifier)) return false;
+
+        JobIdentifier that = (JobIdentifier) o;
+
+        if (pipelineCounter != that.pipelineCounter) return false;
+        if (jobId != that.jobId) return false;
+        if (pipelineName != null ? !pipelineName.equals(that.pipelineName) : that.pipelineName != null) return false;
+        if (pipelineLabel != null ? !pipelineLabel.equals(that.pipelineLabel) : that.pipelineLabel != null)
+            return false;
+        if (staqeName != null ? !staqeName.equals(that.staqeName) : that.staqeName != null) return false;
+        if (stageCounter != null ? !stageCounter.equals(that.stageCounter) : that.stageCounter != null) return false;
+        return jobName != null ? jobName.equals(that.jobName) : that.jobName == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = pipelineName != null ? pipelineName.hashCode() : 0;
+        result = 31 * result + (int) (pipelineCounter ^ (pipelineCounter >>> 32));
+        result = 31 * result + (pipelineLabel != null ? pipelineLabel.hashCode() : 0);
+        result = 31 * result + (staqeName != null ? staqeName.hashCode() : 0);
+        result = 31 * result + (stageCounter != null ? stageCounter.hashCode() : 0);
+        result = 31 * result + (jobName != null ? jobName.hashCode() : 0);
+        result = 31 * result + (int) (jobId ^ (jobId >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "JobIdentifier{" +
+                "pipelineName='" + pipelineName + '\'' +
+                ", pipelineCounter=" + pipelineCounter +
+                ", pipelineLabel='" + pipelineLabel + '\'' +
+                ", staqeName='" + staqeName + '\'' +
+                ", stageCounter='" + stageCounter + '\'' +
+                ", jobName='" + jobName + '\'' +
+                ", jobId=" + jobId +
+                '}';
+    }
+}

--- a/src/main/java/cd/go/contrib/elasticagent/model/JobIdentifier.java
+++ b/src/main/java/cd/go/contrib/elasticagent/model/JobIdentifier.java
@@ -108,4 +108,12 @@ public class JobIdentifier {
                 ", jobId=" + jobId +
                 '}';
     }
+
+    public Long getJobId() {
+        return jobId;
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
 }

--- a/src/main/java/cd/go/contrib/elasticagent/model/KubernetesCluster.java
+++ b/src/main/java/cd/go/contrib/elasticagent/model/KubernetesCluster.java
@@ -33,7 +33,7 @@ public class KubernetesCluster {
 
     public KubernetesCluster(KubernetesClient client) throws ParseException {
         nodes = client.nodes().list().getItems().stream().map(node -> new KubernetesNode(node)).collect(toList());
-        LOG.info("Running docker swarm nodes " + nodes.size());
+        LOG.info("Running kubernetes nodes " + nodes.size());
         fetchPods(client);
     }
 

--- a/src/main/java/cd/go/contrib/elasticagent/requests/CreateAgentRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagent/requests/CreateAgentRequest.java
@@ -50,10 +50,15 @@ public class CreateAgentRequest {
     public CreateAgentRequest() {
     }
 
-    public CreateAgentRequest(String autoRegisterKey, Map<String, String> properties, String environment) {
+    private CreateAgentRequest(String autoRegisterKey, Map<String, String> properties, String environment) {
         this.autoRegisterKey = autoRegisterKey;
         this.properties = properties;
         this.environment = environment;
+    }
+
+    public CreateAgentRequest(String autoRegisterKey, Map<String, String> properties, String environment, JobIdentifier identifier) {
+        this(autoRegisterKey, properties, environment);
+        this.jobIdentifier = identifier;
     }
 
     public static CreateAgentRequest fromJSON(String json) {

--- a/src/main/java/cd/go/contrib/elasticagent/requests/CreateAgentRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagent/requests/CreateAgentRequest.java
@@ -21,6 +21,7 @@ import cd.go.contrib.elasticagent.Constants;
 import cd.go.contrib.elasticagent.PluginRequest;
 import cd.go.contrib.elasticagent.RequestExecutor;
 import cd.go.contrib.elasticagent.executors.CreateAgentRequestExecutor;
+import cd.go.contrib.elasticagent.model.JobIdentifier;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -42,7 +43,9 @@ public class CreateAgentRequest {
     @Expose
     @SerializedName("environment")
     private String environment;
-
+    @Expose
+    @SerializedName("job_identifier")
+    private JobIdentifier jobIdentifier;
 
     public CreateAgentRequest() {
     }
@@ -54,7 +57,8 @@ public class CreateAgentRequest {
     }
 
     public static CreateAgentRequest fromJSON(String json) {
-        return GSON.fromJson(json, CreateAgentRequest.class);
+        CreateAgentRequest createAgentRequest = GSON.fromJson(json, CreateAgentRequest.class);
+        return createAgentRequest;
     }
 
     public String autoRegisterKey() {
@@ -67,6 +71,10 @@ public class CreateAgentRequest {
 
     public String environment() {
         return environment;
+    }
+
+    public JobIdentifier jobIdentifier() {
+        return jobIdentifier;
     }
 
     public RequestExecutor executor(AgentInstances agentInstances, PluginRequest pluginRequest) {
@@ -84,5 +92,15 @@ public class CreateAgentRequest {
         vars.add(new EnvVar("GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID", elasticAgentId, null));
         vars.add(new EnvVar("GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID", Constants.PLUGIN_ID, null));
         return vars;
+    }
+
+    @Override
+    public String toString() {
+        return "CreateAgentRequest{" +
+                "autoRegisterKey='" + autoRegisterKey + '\'' +
+                ", properties=" + properties +
+                ", environment='" + environment + '\'' +
+                ", jobIdentifier=" + jobIdentifier +
+                '}';
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagent/requests/ShouldAssignWorkRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagent/requests/ShouldAssignWorkRequest.java
@@ -21,6 +21,7 @@ import cd.go.contrib.elasticagent.AgentInstances;
 import cd.go.contrib.elasticagent.Request;
 import cd.go.contrib.elasticagent.RequestExecutor;
 import cd.go.contrib.elasticagent.executors.ShouldAssignWorkRequestExecutor;
+import cd.go.contrib.elasticagent.model.JobIdentifier;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -35,20 +36,27 @@ public class ShouldAssignWorkRequest {
     @Expose
     @SerializedName("agent")
     private Agent agent;
+
     @Expose
     @SerializedName("environment")
     private String environment;
+
     @Expose
     @SerializedName("properties")
     private Map<String, String> properties;
 
-    public ShouldAssignWorkRequest(Agent agent, String environment, Map<String, String> properties) {
+    @Expose
+    @SerializedName("job_identifier")
+    private JobIdentifier jobIdentifier;
+
+    public ShouldAssignWorkRequest() {
+    }
+
+    public ShouldAssignWorkRequest(Agent agent, String environment, Map<String, String> properties, JobIdentifier jobIdentifier) {
         this.agent = agent;
         this.environment = environment;
         this.properties = properties;
-    }
-
-    public ShouldAssignWorkRequest() {
+        this.jobIdentifier = jobIdentifier;
     }
 
     public static ShouldAssignWorkRequest fromJSON(String json) {
@@ -69,5 +77,9 @@ public class ShouldAssignWorkRequest {
 
     public RequestExecutor executor(AgentInstances agentInstances) {
         return new ShouldAssignWorkRequestExecutor(this, agentInstances);
+    }
+
+    public JobIdentifier jobIdentifier() {
+        return jobIdentifier;
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/CreateAgentRequestMother.java
+++ b/src/test/java/cd/go/contrib/elasticagent/CreateAgentRequestMother.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.contrib.elasticagent;
+
+import cd.go.contrib.elasticagent.model.JobIdentifier;
+import cd.go.contrib.elasticagent.requests.CreateAgentRequest;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+public class CreateAgentRequestMother {
+    public static CreateAgentRequest defaultCreateAgentRequest() {
+        String autoRegisterKey = UUID.randomUUID().toString();
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put("Image", "gocd/custom-gocd-agent-alpine");
+        properties.put("MaxMemory", "1024m");
+        properties.put("MaxCPU", "1");
+        properties.put("Environment", "ENV1=VALUE1\n" +
+                "ENV2=VALUE2");
+        properties.put("PodConfiguration", "");
+        properties.put("SpecifiedUsingPodConfiguration", "false");
+
+        String environment = "QA";
+        JobIdentifier identifier = new JobIdentifier("up_42", 1L, "up_42_label", "up42_stage", "20", "up42_job", 10L);
+        return new CreateAgentRequest(autoRegisterKey, properties, environment, identifier);
+    }
+
+    public static CreateAgentRequest createAgentRequestUsingPodYaml() {
+        String podYaml = "apiVersion: v1\n" +
+                "kind: Pod\n" +
+                "metadata:\n" +
+                "  name: test-pod-yaml\n" +
+                "  labels:\n" +
+                "    app: gocd-agent\n" +
+                "  annotations:\n" +
+                "    annotation-key: my-fancy-annotation-value\n" +
+                "spec:\n" +
+                "  containers:\n" +
+                "  - name: gocd-agent-container\n" +
+                "    image: gocd/gocd-agent-alpine-3.5:v17.12.0\n" +
+                "    imagePullPolicy: Always\n" +
+                "    env:\n" +
+                "    - name: DEMO_ENV\n" +
+                "      value: DEMO_FANCY_VALUE\n" +
+                "    ports:\n" +
+                "    - containerPort: 80";
+
+        String autoRegisterKey = UUID.randomUUID().toString();
+        HashMap<String, String> properties = new HashMap<>();
+
+        properties.put("PodConfiguration", podYaml);
+        properties.put("SpecifiedUsingPodConfiguration", "true");
+
+        String environment = "QA";
+        JobIdentifier identifier = new JobIdentifier("up_42", 1L, "up_42_label", "up42_stage", "20", "up42_job", 10L);
+        return new CreateAgentRequest(autoRegisterKey, properties, environment, identifier);
+    }
+}

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesIntegrationTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesIntegrationTest.java
@@ -160,7 +160,6 @@ public class KubernetesAgentInstancesIntegrationTest {
         HashMap<String, String> labels = new HashMap<>();
         labels.put(Constants.CREATED_BY_LABEL_KEY, Constants.PLUGIN_ID);
         labels.put(Constants.JOB_ID_LABEL_KEY, createAgentRequest.jobIdentifier().getJobId().toString());
-        labels.put(Constants.JOB_NAME_LABEL_KEY, createAgentRequest.jobIdentifier().getJobName());
         labels.put(Constants.KUBERNETES_POD_KIND_LABEL_KEY, Constants.KUBERNETES_POD_KIND_LABEL_VALUE);
         labels.put(Constants.ENVIRONMENT_LABEL_KEY, createAgentRequest.environment());
 
@@ -268,7 +267,6 @@ public class KubernetesAgentInstancesIntegrationTest {
         HashMap<String, String> labels = new HashMap<>();
         labels.put(Constants.CREATED_BY_LABEL_KEY, Constants.PLUGIN_ID);
         labels.put(Constants.JOB_ID_LABEL_KEY, createAgentRequest.jobIdentifier().getJobId().toString());
-        labels.put(Constants.JOB_NAME_LABEL_KEY, createAgentRequest.jobIdentifier().getJobName());
         labels.put(Constants.KUBERNETES_POD_KIND_LABEL_KEY, Constants.KUBERNETES_POD_KIND_LABEL_VALUE);
         labels.put(Constants.ENVIRONMENT_LABEL_KEY, createAgentRequest.environment());
 

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesIntegrationTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesIntegrationTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.contrib.elasticagent;
+
+import cd.go.contrib.elasticagent.requests.CreateAgentRequest;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.NodeOperationsImpl;
+import io.fabric8.kubernetes.client.dsl.internal.PodOperationsImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class KubernetesAgentInstancesIntegrationTest {
+
+    @Mock
+    private KubernetesClientFactory mockedKubernetesClientFactory;
+
+    @Mock
+    private PluginRequest mockedPluginRequest;
+
+    private KubernetesAgentInstances kubernetesAgentInstances;
+    private PluginSettings settings;
+    private CreateAgentRequest createAgentRequest;
+
+    @Mock
+    private KubernetesClient mockKubernetesClient;
+
+    @Mock
+    private NodeOperationsImpl nodes;
+
+    @Mock
+    private PodOperationsImpl pods;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        kubernetesAgentInstances = new KubernetesAgentInstances(mockedKubernetesClientFactory);
+        when(mockedKubernetesClientFactory.kubernetes(any())).thenReturn(mockKubernetesClient);
+
+        when(pods.inNamespace(Constants.KUBERNETES_NAMESPACE_KEY)).thenReturn(pods);
+        when(pods.list()).thenReturn(new PodList());
+        when(mockKubernetesClient.pods()).thenReturn(pods);
+
+        createAgentRequest = CreateAgentRequestMother.defaultCreateAgentRequest();
+        settings = PluginSettingsMother.defaultPluginSettings();
+    }
+
+    @Test
+    public void shouldCreateKubernetesPodForCreateAgentRequest() throws Exception {
+        KubernetesInstance kubernetesInstance = kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+
+        assertTrue(kubernetesAgentInstances.instanceExists(kubernetesInstance));
+    }
+
+    @Test
+    public void shouldCreateKubernetesPodWithContainerSpecification() throws Exception {
+        ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
+        KubernetesInstance instance = kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+        verify(pods).create(argumentCaptor.capture());
+        Pod elasticAgentPod = argumentCaptor.getValue();
+
+        List<Container> containers = elasticAgentPod.getSpec().getContainers();
+        assertThat(containers.size(), is(1));
+
+        Container gocdAgentContainer = containers.get(0);
+
+        assertThat(gocdAgentContainer.getName(), is(instance.name()));
+
+        assertThat(gocdAgentContainer.getImage(), is("gocd/custom-gocd-agent-alpine:latest"));
+        assertThat(gocdAgentContainer.getImagePullPolicy(), is("IfNotPresent"));
+    }
+
+    @Test
+    public void shouldCreateKubernetesPodWithPodMetadata() throws Exception {
+        ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
+        KubernetesInstance instance = kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+        verify(pods).create(argumentCaptor.capture());
+
+        Pod elasticAgentPod = argumentCaptor.getValue();
+
+        assertNotNull(elasticAgentPod.getMetadata());
+        assertThat(elasticAgentPod.getMetadata().getName(), is(instance.name()));
+    }
+
+    @Test
+    public void shouldCreateKubernetesPodWithGoCDElasticAgentContainerContainingEnvironmentVariables() throws Exception {
+        ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
+        KubernetesInstance instance = kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+        verify(pods).create(argumentCaptor.capture());
+        Pod elasticAgentPod = argumentCaptor.getValue();
+
+        ArrayList<EnvVar> expectedEnvVars = new ArrayList<>();
+        expectedEnvVars.add(new EnvVar("GO_EA_SERVER_URL", settings.getGoServerUrl(), null));
+
+        expectedEnvVars.add(new EnvVar("ENV1", "VALUE1", null));
+        expectedEnvVars.add(new EnvVar("ENV2", "VALUE2", null));
+
+        expectedEnvVars.add(new EnvVar("GO_EA_AUTO_REGISTER_KEY", createAgentRequest.autoRegisterKey(), null));
+        expectedEnvVars.add(new EnvVar("GO_EA_AUTO_REGISTER_ENVIRONMENT", createAgentRequest.environment(), null));
+        expectedEnvVars.add(new EnvVar("GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID", instance.name(), null));
+        expectedEnvVars.add(new EnvVar("GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID", Constants.PLUGIN_ID, null));
+
+        List<Container> containers = elasticAgentPod.getSpec().getContainers();
+        assertThat(containers.size(), is(1));
+
+        assertThat(containers.get(0).getEnv(), is(expectedEnvVars));
+    }
+
+    @Test
+    public void shouldCreateKubernetesPodWithPodAnnotations() throws Exception {
+        ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
+        kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+        verify(pods).create(argumentCaptor.capture());
+        Pod elasticAgentPod = argumentCaptor.getValue();
+
+        assertNotNull(elasticAgentPod.getMetadata());
+
+        assertThat(elasticAgentPod.getMetadata().getAnnotations(), is(createAgentRequest.properties()));
+    }
+
+    @Test
+    public void shouldCreateKubernetesPodWithPodLabels() throws Exception {
+        ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
+        kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+        verify(pods).create(argumentCaptor.capture());
+        Pod elasticAgentPod = argumentCaptor.getValue();
+
+        assertNotNull(elasticAgentPod.getMetadata());
+
+        HashMap<String, String> labels = new HashMap<>();
+        labels.put(Constants.CREATED_BY_LABEL_KEY, Constants.PLUGIN_ID);
+        labels.put(Constants.JOB_ID_LABEL_KEY, createAgentRequest.jobIdentifier().getJobId().toString());
+        labels.put(Constants.JOB_NAME_LABEL_KEY, createAgentRequest.jobIdentifier().getJobName());
+        labels.put(Constants.KUBERNETES_POD_KIND_LABEL_KEY, Constants.KUBERNETES_POD_KIND_LABEL_VALUE);
+        labels.put(Constants.ENVIRONMENT_LABEL_KEY, createAgentRequest.environment());
+
+        assertThat(elasticAgentPod.getMetadata().getLabels(), is(labels));
+    }
+
+    //Tests Using Pod Yaml
+
+    @Test
+    public void usingPodYamlConfigurations_shouldCreateKubernetesPodForCreateAgentRequest() throws Exception {
+        createAgentRequest = CreateAgentRequestMother.createAgentRequestUsingPodYaml();
+        KubernetesInstance kubernetesInstance = kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+
+        assertTrue(kubernetesAgentInstances.instanceExists(kubernetesInstance));
+    }
+
+    @Test
+    public void usingPodYamlConfigurations_shouldCreateKubernetesPodWithContainerSpecification() throws Exception {
+        createAgentRequest = CreateAgentRequestMother.createAgentRequestUsingPodYaml();
+
+        ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
+        kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+        verify(pods).create(argumentCaptor.capture());
+        Pod elasticAgentPod = argumentCaptor.getValue();
+
+        List<Container> containers = elasticAgentPod.getSpec().getContainers();
+        assertThat(containers.size(), is(1));
+
+        Container gocdAgentContainer = containers.get(0);
+
+        assertThat(gocdAgentContainer.getName(), is("gocd-agent-container"));
+        assertThat(gocdAgentContainer.getImage(), is("gocd/gocd-agent-alpine-3.5:v17.12.0"));
+        assertThat(gocdAgentContainer.getImagePullPolicy(), is("Always"));
+    }
+
+    @Test
+    public void usingPodYamlConfigurations_shouldCreateKubernetesPodWithPodMetadata() throws Exception {
+        createAgentRequest = CreateAgentRequestMother.createAgentRequestUsingPodYaml();
+
+        ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
+        KubernetesInstance instance = kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+        verify(pods).create(argumentCaptor.capture());
+
+        Pod elasticAgentPod = argumentCaptor.getValue();
+
+        assertNotNull(elasticAgentPod.getMetadata());
+        assertThat(elasticAgentPod.getMetadata().getName(), is("test-pod-yaml"));
+
+        assertThat(elasticAgentPod.getMetadata().getName(), is(instance.name()));
+    }
+
+    @Test
+    public void usingPodYamlConfigurations_shouldCreateKubernetesPodWithGoCDElasticAgentContainerContainingEnvironmentVariables() throws Exception {
+        createAgentRequest = CreateAgentRequestMother.createAgentRequestUsingPodYaml();
+
+        ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
+        KubernetesInstance instance = kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+        verify(pods).create(argumentCaptor.capture());
+        Pod elasticAgentPod = argumentCaptor.getValue();
+
+        ArrayList<EnvVar> expectedEnvVars = new ArrayList<>();
+        expectedEnvVars.add(new EnvVar("DEMO_ENV", "DEMO_FANCY_VALUE", null));
+
+        expectedEnvVars.add(new EnvVar("GO_EA_SERVER_URL", settings.getGoServerUrl(), null));
+        expectedEnvVars.add(new EnvVar("GO_EA_AUTO_REGISTER_KEY", createAgentRequest.autoRegisterKey(), null));
+        expectedEnvVars.add(new EnvVar("GO_EA_AUTO_REGISTER_ENVIRONMENT", createAgentRequest.environment(), null));
+        expectedEnvVars.add(new EnvVar("GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID", instance.name(), null));
+        expectedEnvVars.add(new EnvVar("GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID", Constants.PLUGIN_ID, null));
+
+        List<Container> containers = elasticAgentPod.getSpec().getContainers();
+        assertThat(containers.size(), is(1));
+
+        assertThat(containers.get(0).getEnv(), is(expectedEnvVars));
+    }
+
+    @Test
+    public void usingPodYamlConfigurations_shouldCreateKubernetesPodWithPodAnnotations() throws Exception {
+        createAgentRequest = CreateAgentRequestMother.createAgentRequestUsingPodYaml();
+
+        ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
+        kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+        verify(pods).create(argumentCaptor.capture());
+        Pod elasticAgentPod = argumentCaptor.getValue();
+
+        assertNotNull(elasticAgentPod.getMetadata());
+
+        HashMap<String, String> expectedAnnotations = new HashMap<>();
+        expectedAnnotations.putAll(createAgentRequest.properties());
+        expectedAnnotations.put("annotation-key", "my-fancy-annotation-value");
+
+        assertThat(elasticAgentPod.getMetadata().getAnnotations(), is(expectedAnnotations));
+    }
+
+    @Test
+    public void usingPodYamlConfigurations_shouldCreateKubernetesPodWithPodLabels() throws Exception {
+        createAgentRequest = CreateAgentRequestMother.createAgentRequestUsingPodYaml();
+
+        ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
+        kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+        verify(pods).create(argumentCaptor.capture());
+        Pod elasticAgentPod = argumentCaptor.getValue();
+
+        assertNotNull(elasticAgentPod.getMetadata());
+
+        HashMap<String, String> labels = new HashMap<>();
+        labels.put(Constants.CREATED_BY_LABEL_KEY, Constants.PLUGIN_ID);
+        labels.put(Constants.JOB_ID_LABEL_KEY, createAgentRequest.jobIdentifier().getJobId().toString());
+        labels.put(Constants.JOB_NAME_LABEL_KEY, createAgentRequest.jobIdentifier().getJobName());
+        labels.put(Constants.KUBERNETES_POD_KIND_LABEL_KEY, Constants.KUBERNETES_POD_KIND_LABEL_VALUE);
+        labels.put(Constants.ENVIRONMENT_LABEL_KEY, createAgentRequest.environment());
+
+        labels.put("app", "gocd-agent");
+
+        assertThat(elasticAgentPod.getMetadata().getLabels(), is(labels));
+    }
+
+}

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.contrib.elasticagent;
+
+import cd.go.contrib.elasticagent.requests.CreateAgentRequest;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.internal.PodOperationsImpl;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class KubernetesAgentInstancesTest {
+    @Mock
+    KubernetesClientFactory factory;
+
+    @Mock
+    KubernetesInstanceFactory kubernetesInstanceFactory;
+
+    @Mock
+    CreateAgentRequest mockCreateAgentRequest;
+
+    @Mock
+    PluginSettings mockPluginSettings;
+
+    @Mock
+    KubernetesClient mockKubernetesClient;
+
+    @Mock
+    PluginRequest mockPluginRequest;
+
+    @Mock
+    PodOperationsImpl mockPods;
+    private HashMap<String, String> testProperties;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        testProperties = new HashMap<>();
+        when(mockCreateAgentRequest.properties()).thenReturn(testProperties);
+        when(factory.kubernetes(mockPluginSettings)).thenReturn(mockKubernetesClient);
+    }
+
+    @Test
+    public void shouldCreateKubernetesPodUsingPodYamlAndCacheCreatedInstance() throws Exception {
+        KubernetesInstance kubernetesInstance = new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>());
+        when(kubernetesInstanceFactory.create(mockCreateAgentRequest, mockPluginSettings, mockKubernetesClient, mockPluginRequest, true)).
+                thenReturn(kubernetesInstance);
+
+        testProperties.put("SpecifiedUsingPodConfiguration", "true");
+
+        KubernetesAgentInstances agentInstances = new KubernetesAgentInstances(factory, kubernetesInstanceFactory);
+        KubernetesInstance instance = agentInstances.create(mockCreateAgentRequest, mockPluginSettings, mockPluginRequest);
+        assertTrue(agentInstances.instanceExists(instance));
+    }
+
+    @Test
+    public void shouldCreateKubernetesPodAndCacheCreatedInstance() throws Exception {
+        KubernetesInstance kubernetesInstance = new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>());
+        when(kubernetesInstanceFactory.create(mockCreateAgentRequest, mockPluginSettings, mockKubernetesClient, mockPluginRequest, false)).
+                thenReturn(kubernetesInstance);
+        testProperties.put("SpecifiedUsingPodConfiguration", "false");
+        KubernetesAgentInstances agentInstances = new KubernetesAgentInstances(factory, kubernetesInstanceFactory);
+        KubernetesInstance instance = agentInstances.create(mockCreateAgentRequest, mockPluginSettings, mockPluginRequest);
+        assertTrue(agentInstances.instanceExists(instance));
+    }
+
+}

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesTest.java
@@ -65,7 +65,7 @@ public class KubernetesAgentInstancesTest {
 
     @Test
     public void shouldCreateKubernetesPodUsingPodYamlAndCacheCreatedInstance() throws Exception {
-        KubernetesInstance kubernetesInstance = new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>());
+        KubernetesInstance kubernetesInstance = new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>(), null);
         when(mockKubernetesInstanceFactory.create(mockCreateAgentRequest, mockPluginSettings, mockKubernetesClient, mockPluginRequest, true)).
                 thenReturn(kubernetesInstance);
 
@@ -78,7 +78,7 @@ public class KubernetesAgentInstancesTest {
 
     @Test
     public void shouldCreateKubernetesPodAndCacheCreatedInstance() throws Exception {
-        KubernetesInstance kubernetesInstance = new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>());
+        KubernetesInstance kubernetesInstance = new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>(), null);
         when(mockKubernetesInstanceFactory.create(mockCreateAgentRequest, mockPluginSettings, mockKubernetesClient, mockPluginRequest, false)).
                 thenReturn(kubernetesInstance);
         testProperties.put("SpecifiedUsingPodConfiguration", "false");

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesTest.java
@@ -86,22 +86,4 @@ public class KubernetesAgentInstancesTest {
         KubernetesInstance instance = agentInstances.create(mockCreateAgentRequest, mockPluginSettings, mockPluginRequest);
         assertTrue(agentInstances.instanceExists(instance));
     }
-
-    @Test
-    public void shouldNotCreatePodWhenOutstandingRequestsExistForJobs() throws Exception {
-        KubernetesInstance kubernetesInstance = new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>());
-        when(mockKubernetesInstanceFactory.create(mockCreateAgentRequest, mockPluginSettings, mockKubernetesClient, mockPluginRequest, false)).
-                thenReturn(kubernetesInstance);
-        testProperties.put("SpecifiedUsingPodConfiguration", "false");
-
-        KubernetesAgentInstances agentInstances = new KubernetesAgentInstances(factory, mockKubernetesInstanceFactory);
-        JobIdentifier jobId = new JobIdentifier("test", 1L, "Test pipeline", "test name", "1", "test job", 100L);
-        when(mockCreateAgentRequest.jobIdentifier()).thenReturn(jobId);
-        agentInstances.create(mockCreateAgentRequest, mockPluginSettings, mockPluginRequest);
-        verify(mockKubernetesInstanceFactory, times(1)).create(any(), any(), any(), any(), any());
-        reset(mockKubernetesInstanceFactory);
-
-        agentInstances.create(mockCreateAgentRequest, mockPluginSettings, mockPluginRequest);
-        verify(mockKubernetesInstanceFactory, times(0)).create(any(), any(), any(), any(), any());
-    }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/PluginSettingsMother.java
+++ b/src/test/java/cd/go/contrib/elasticagent/PluginSettingsMother.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.contrib.elasticagent;
+
+public class PluginSettingsMother {
+    public static PluginSettings defaultPluginSettings() {
+        return PluginSettings.fromJSON("{" +
+                "\"go_server_url\": \"https://foo.go.cd/go\", " +
+                "\"auto_register_timeout\": \"10\", " +
+                "\"kubernetes_cluster_url\": \"https://cloud.example.com\", " +
+                "\"kubernetes_cluster_username\": \"admin\", " +
+                "\"kubernetes_cluster_password\": \"password\", " +
+                "\"kubernetes_cluster_ca_cert\": \"my awesome ca cert\" " +
+                "}");
+    }
+}

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
@@ -131,7 +131,7 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         verifyNoMoreInteractions(pluginRequest);
 
         new ServerPingRequestExecutor(agentInstances, pluginRequest).execute();
-        assertFalse(agentInstances.hasInstance(container.name()));
+        assertFalse(agentInstances.instanceExists(container));
     }
 
     @Test

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
@@ -17,6 +17,7 @@
 package cd.go.contrib.elasticagent.executors;
 
 import cd.go.contrib.elasticagent.*;
+import cd.go.contrib.elasticagent.model.JobIdentifier;
 import cd.go.contrib.elasticagent.requests.CreateAgentRequest;
 import io.fabric8.kubernetes.api.model.DoneablePod;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -116,7 +117,7 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         KubernetesAgentInstances agentInstances = new KubernetesAgentInstances(factory);
         HashMap<String, String> properties = new HashMap<>();
         properties.put("Image", "foo");
-        KubernetesInstance container = agentInstances.create(new CreateAgentRequest(null, properties, null), createSettings(), null);
+        KubernetesInstance container = agentInstances.create(new CreateAgentRequest(null, properties, null, new JobIdentifier()), createSettings(), null);
 
         agentInstances.clock = new Clock.TestClock().forward(Period.minutes(11));
         PluginRequest pluginRequest = mock(PluginRequest.class);

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
@@ -117,13 +117,15 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         KubernetesAgentInstances agentInstances = new KubernetesAgentInstances(factory);
         HashMap<String, String> properties = new HashMap<>();
         properties.put("Image", "foo");
-        KubernetesInstance container = agentInstances.create(new CreateAgentRequest(null, properties, null, new JobIdentifier()), createSettings(), null);
+        KubernetesInstance container = agentInstances.create(new CreateAgentRequest(null, properties, null, new JobIdentifier(1L)), createSettings(), null);
 
         agentInstances.clock = new Clock.TestClock().forward(Period.minutes(11));
         PluginRequest pluginRequest = mock(PluginRequest.class);
 
         objectMetadata.setName(container.name());
-        objectMetadata.setLabels(new HashMap<>());
+        HashMap<String, String> labels = new HashMap<>();
+        labels.put(Constants.JOB_ID_LABEL_KEY, "1");
+        objectMetadata.setLabels(labels);
         when(pluginRequest.getPluginSettings()).thenReturn(createSettings());
         when(pluginRequest.listAgents()).thenReturn(new Agents());
         verifyNoMoreInteractions(pluginRequest);

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 
-import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static cd.go.contrib.elasticagent.utils.Util.getSimpleDateFormat;

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutorTest.java
@@ -45,7 +45,6 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
-    private final String environment = "production";
     @Mock
     KubernetesClientFactory factory;
     private AgentInstances<KubernetesInstance> agentInstances;
@@ -57,6 +56,7 @@ public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
     private MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockedOperation;
     @Mock
     private NonNamespaceOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockedNamespaceOperation;
+    private String environment = "QA";
 
     @Before
     public void setUp() throws Exception {
@@ -69,28 +69,23 @@ public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
         agentInstances = new KubernetesAgentInstances(factory);
         properties.put("foo", "bar");
         properties.put("Image", "gocdcontrib/ubuntu-docker-elastic-agent");
-        instance = agentInstances.create(new CreateAgentRequest(UUID.randomUUID().toString(), properties, environment, new JobIdentifier(1L)), createSettings(), null);
+        instance = agentInstances.create(new CreateAgentRequest(UUID.randomUUID().toString(), properties, environment, new JobIdentifier(100L)), createSettings(), null);
     }
 
     @Test
-    public void shouldAssignWorkToContainerWithMatchingEnvironmentNameAndProperties() throws Exception {
-        ShouldAssignWorkRequest request = new ShouldAssignWorkRequest(new Agent(instance.name(), null, null, null), environment, properties);
+    public void shouldAssignWorkWhenJobIdMatchesPodId() throws Exception {
+        JobIdentifier jobIdentifier = new JobIdentifier("test-pipeline", 1L, "Test Pipeline", "test-stage", "1", "test-job", 100L);
+        ShouldAssignWorkRequest request = new ShouldAssignWorkRequest(new Agent(instance.name(), null, null, null), environment, properties, jobIdentifier);
         GoPluginApiResponse response = new ShouldAssignWorkRequestExecutor(request, agentInstances).execute();
         assertThat(response.responseCode(), is(200));
         assertThat(response.responseBody(), is("true"));
     }
 
     @Test
-    public void shouldNotAssignWorkToContainerWithDifferentEnvironmentName() throws Exception {
-        ShouldAssignWorkRequest request = new ShouldAssignWorkRequest(new Agent(instance.name(), null, null, null), "FooEnv", properties);
-        GoPluginApiResponse response = new ShouldAssignWorkRequestExecutor(request, agentInstances).execute();
-        assertThat(response.responseCode(), is(200));
-        assertThat(response.responseBody(), is("false"));
-    }
-
-    @Test
-    public void shouldNotAssignWorkToContainerWithDifferentProperties() throws Exception {
-        ShouldAssignWorkRequest request = new ShouldAssignWorkRequest(new Agent(instance.name(), null, null, null), environment, null);
+    public void shouldNotAssignWorkWhenJobIdDiffersFromPodId() throws Exception {
+        long mismatchingJobId = 200L;
+        JobIdentifier jobIdentifier = new JobIdentifier("test-pipeline", 1L, "Test Pipeline", "test-stage", "1", "test-job", mismatchingJobId);
+        ShouldAssignWorkRequest request = new ShouldAssignWorkRequest(new Agent(instance.name(), null, null, null), "FooEnv", properties, jobIdentifier);
         GoPluginApiResponse response = new ShouldAssignWorkRequestExecutor(request, agentInstances).execute();
         assertThat(response.responseCode(), is(200));
         assertThat(response.responseBody(), is("false"));

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutorTest.java
@@ -69,7 +69,7 @@ public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
         agentInstances = new KubernetesAgentInstances(factory);
         properties.put("foo", "bar");
         properties.put("Image", "gocdcontrib/ubuntu-docker-elastic-agent");
-        instance = agentInstances.create(new CreateAgentRequest(UUID.randomUUID().toString(), properties, environment, new JobIdentifier()), createSettings(), null);
+        instance = agentInstances.create(new CreateAgentRequest(UUID.randomUUID().toString(), properties, environment, new JobIdentifier(1L)), createSettings(), null);
     }
 
     @Test

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutorTest.java
@@ -17,6 +17,7 @@
 package cd.go.contrib.elasticagent.executors;
 
 import cd.go.contrib.elasticagent.*;
+import cd.go.contrib.elasticagent.model.JobIdentifier;
 import cd.go.contrib.elasticagent.requests.CreateAgentRequest;
 import cd.go.contrib.elasticagent.requests.ShouldAssignWorkRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
@@ -68,7 +69,7 @@ public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
         agentInstances = new KubernetesAgentInstances(factory);
         properties.put("foo", "bar");
         properties.put("Image", "gocdcontrib/ubuntu-docker-elastic-agent");
-        instance = agentInstances.create(new CreateAgentRequest(UUID.randomUUID().toString(), properties, environment), createSettings(), null);
+        instance = agentInstances.create(new CreateAgentRequest(UUID.randomUUID().toString(), properties, environment, new JobIdentifier()), createSettings(), null);
     }
 
     @Test

--- a/src/test/java/cd/go/contrib/elasticagent/requests/CreateAgentRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/requests/CreateAgentRequestTest.java
@@ -57,7 +57,7 @@ public class CreateAgentRequestTest {
         expectedProperties.put("key2", "value2");
         assertThat(request.properties(), Matchers.<Map<String, String>>equalTo(expectedProperties));
 
-        JobIdentifier expectedJobIdentifier = new JobIdentifier("test-pipeline", 1, "Test Pipeline", "test-stage", "1", "test-job", 100);
+        JobIdentifier expectedJobIdentifier = new JobIdentifier("test-pipeline", 1L, "Test Pipeline", "test-stage", "1", "test-job", 100L);
         JobIdentifier actualJobIdentifier = request.jobIdentifier();
 
         assertThat(actualJobIdentifier, is(expectedJobIdentifier));

--- a/src/test/java/cd/go/contrib/elasticagent/requests/CreateAgentRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/requests/CreateAgentRequestTest.java
@@ -16,6 +16,7 @@
 
 package cd.go.contrib.elasticagent.requests;
 
+import cd.go.contrib.elasticagent.model.JobIdentifier;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -23,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class CreateAgentRequestTest {
@@ -35,7 +37,16 @@ public class CreateAgentRequestTest {
                 "    \"key1\": \"value1\",\n" +
                 "    \"key2\": \"value2\"\n" +
                 "  },\n" +
-                "  \"environment\": \"prod\"\n" +
+                "  \"environment\": \"prod\",\n" +
+                "  \"job_identifier\": {\n" +
+                "    \"pipeline_name\": \"test-pipeline\",\n" +
+                "    \"pipeline_counter\": 1,\n" +
+                "    \"pipeline_label\": \"Test Pipeline\",\n" +
+                "    \"stage_name\": \"test-stage\",\n" +
+                "    \"stage_counter\": \"1\",\n" +
+                "    \"job_name\": \"test-job\",\n" +
+                "    \"job_id\": 100\n" +
+                "  }\n" +
                 "}";
 
         CreateAgentRequest request = CreateAgentRequest.fromJSON(json);
@@ -46,5 +57,9 @@ public class CreateAgentRequestTest {
         expectedProperties.put("key2", "value2");
         assertThat(request.properties(), Matchers.<Map<String, String>>equalTo(expectedProperties));
 
+        JobIdentifier expectedJobIdentifier = new JobIdentifier("test-pipeline", 1, "Test Pipeline", "test-stage", "1", "test-job", 100);
+        JobIdentifier actualJobIdentifier = request.jobIdentifier();
+
+        assertThat(actualJobIdentifier, is(expectedJobIdentifier));
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/requests/ShouldAssignWorkRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/requests/ShouldAssignWorkRequestTest.java
@@ -17,6 +17,7 @@
 package cd.go.contrib.elasticagent.requests;
 
 import cd.go.contrib.elasticagent.Agent;
+import cd.go.contrib.elasticagent.model.JobIdentifier;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -24,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class ShouldAssignWorkRequestTest {
@@ -40,6 +42,15 @@ public class ShouldAssignWorkRequestTest {
                 "  },\n" +
                 "  \"properties\": {\n" +
                 "    \"property_name\": \"property_value\"\n" +
+                "  },\n" +
+                "  \"job_identifier\": {\n" +
+                "    \"pipeline_name\": \"test-pipeline\",\n" +
+                "    \"pipeline_counter\": 1,\n" +
+                "    \"pipeline_label\": \"Test Pipeline\",\n" +
+                "    \"stage_name\": \"test-stage\",\n" +
+                "    \"stage_counter\": \"1\",\n" +
+                "    \"job_name\": \"test-job\",\n" +
+                "    \"job_id\": 100\n" +
                 "  }\n" +
                 "}";
 
@@ -49,5 +60,10 @@ public class ShouldAssignWorkRequestTest {
         HashMap<String, String> expectedProperties = new HashMap<>();
         expectedProperties.put("property_name", "property_value");
         assertThat(request.properties(), Matchers.<Map<String, String>>equalTo(expectedProperties));
+
+        JobIdentifier expectedJobIdentifier = new JobIdentifier("test-pipeline", 1L, "Test Pipeline", "test-stage", "1", "test-job", 100L);
+        JobIdentifier actualJobIdentifier = request.jobIdentifier();
+
+        assertThat(actualJobIdentifier, is(expectedJobIdentifier));
     }
 }


### PR DESCRIPTION
Use job identifier information while:
* Creating an elastic agent
    - to make sure that only one elastic agent is created per job
* Assigning an agent to the job
    - to assign the same elastic agent which was brought up for the current job.