### PR TITLE
Use JobIdentifier information provided as part of get-status-report request to show the relation between job and pod

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesPlugin.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesPlugin.java
@@ -17,10 +17,7 @@
 package cd.go.contrib.elasticagent;
 
 import cd.go.contrib.elasticagent.executors.*;
-import cd.go.contrib.elasticagent.requests.CreateAgentRequest;
-import cd.go.contrib.elasticagent.requests.ProfileValidateRequest;
-import cd.go.contrib.elasticagent.requests.ShouldAssignWorkRequest;
-import cd.go.contrib.elasticagent.requests.ValidatePluginSettings;
+import cd.go.contrib.elasticagent.requests.*;
 import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
 import com.thoughtworks.go.plugin.api.GoPlugin;
 import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
@@ -76,7 +73,8 @@ public class KubernetesPlugin implements GoPlugin {
                     refreshInstances();
                     return new ServerPingRequestExecutor(agentInstances, pluginRequest).execute();
                 case REQUEST_STATUS_REPORT:
-                    return new StatusReportExecutor(pluginRequest).execute();
+                    return StatusReportRequest.fromJSON(request.requestBody()).executor(pluginRequest).execute();
+//                    return new StatusReportExecutor(pluginRequest).execute();
                 default:
                     throw new UnhandledRequestTypeException(request.requestName());
             }

--- a/src/main/java/cd/go/contrib/elasticagent/builders/PluginStatusReportViewBuilder.java
+++ b/src/main/java/cd/go/contrib/elasticagent/builders/PluginStatusReportViewBuilder.java
@@ -17,6 +17,7 @@
 package cd.go.contrib.elasticagent.builders;
 
 import cd.go.contrib.elasticagent.model.KubernetesCluster;
+import cd.go.contrib.elasticagent.model.StatusReportInformation;
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -44,9 +45,9 @@ public class PluginStatusReportViewBuilder {
         return configuration.getTemplate(template);
     }
 
-    public String build(Template template, KubernetesCluster cluster) throws IOException, TemplateException {
+    public String build(Template template, StatusReportInformation reportInformation) throws IOException, TemplateException {
         Writer writer = new StringWriter();
-        template.process(cluster, writer);
+        template.process(reportInformation, writer);
         return writer.toString();
     }
 

--- a/src/main/java/cd/go/contrib/elasticagent/model/StatusReportInformation.java
+++ b/src/main/java/cd/go/contrib/elasticagent/model/StatusReportInformation.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.contrib.elasticagent.model;
+
+import java.util.List;
+
+public class StatusReportInformation {
+    private KubernetesCluster cluster;
+    private JobIdentifier identifier;
+
+    public StatusReportInformation(KubernetesCluster cluster, JobIdentifier identifier) {
+        this.cluster = cluster;
+        this.identifier = identifier;
+    }
+
+    public List<KubernetesNode> getNodes() {
+        return cluster.getNodes();
+    }
+
+    public String getJobInformation() {
+        return identifier.representation();
+    }
+}

--- a/src/main/java/cd/go/contrib/elasticagent/requests/StatusReportRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagent/requests/StatusReportRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.contrib.elasticagent.requests;
+
+import cd.go.contrib.elasticagent.AgentInstances;
+import cd.go.contrib.elasticagent.Constants;
+import cd.go.contrib.elasticagent.PluginRequest;
+import cd.go.contrib.elasticagent.RequestExecutor;
+import cd.go.contrib.elasticagent.executors.CreateAgentRequestExecutor;
+import cd.go.contrib.elasticagent.executors.StatusReportExecutor;
+import cd.go.contrib.elasticagent.model.JobIdentifier;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import io.fabric8.kubernetes.api.model.EnvVar;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import static cd.go.contrib.elasticagent.utils.Util.GSON;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class StatusReportRequest {
+    @Expose
+    @SerializedName("job_identifier")
+    private JobIdentifier jobIdentifier;
+
+    public StatusReportRequest() {
+    }
+
+    public StatusReportRequest(JobIdentifier identifier) {
+        this.jobIdentifier = identifier;
+    }
+
+    public static StatusReportRequest fromJSON(String json) {
+        StatusReportRequest statusReportRequest = GSON.fromJson(json, StatusReportRequest.class);
+        return statusReportRequest;
+    }
+
+
+    public JobIdentifier jobIdentifier() {
+        return jobIdentifier;
+    }
+
+    public RequestExecutor executor(PluginRequest pluginRequest) throws IOException {
+        return new StatusReportExecutor(this, pluginRequest);
+    }
+
+    @Override
+    public String toString() {
+        return "StatusReportRequest{" +
+                "jobIdentifier=" + jobIdentifier +
+                '}';
+    }
+}

--- a/src/main/resources/status-report.template.ftlh
+++ b/src/main/resources/status-report.template.ftlh
@@ -149,6 +149,12 @@
         background: #fff;
         border-radius: 2px;
     }
+
+    [data-plugin-style-id="kubernetes-plugin"] .active_job {
+        background: #ffeda0;
+        border-bottom: 1px solid #ff
+    }
+
 </style>
 
 <div data-plugin-style-id="kubernetes-plugin">
@@ -233,7 +239,11 @@
                         <tbody>
                             <#if node.pods?size != 0>
                                 <#list node.pods as pod>
-                                <tr>
+                                <tr
+                                    <#if pod.jobInformation == jobInformation>
+                                            class="active_job"
+                                    </#if>
+                                >
                                     <td>${pod.podName!}</td>
                                     <td>${pod.jobInformation!}</td>
                                     <td>${pod.image!}</td>

--- a/src/test/java/cd/go/contrib/elasticagent/executors/StatusReportExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/StatusReportExecutorTest.java
@@ -22,6 +22,8 @@ import cd.go.contrib.elasticagent.PluginRequest;
 import cd.go.contrib.elasticagent.PluginSettings;
 import cd.go.contrib.elasticagent.builders.PluginStatusReportViewBuilder;
 import cd.go.contrib.elasticagent.model.KubernetesCluster;
+import cd.go.contrib.elasticagent.model.StatusReportInformation;
+import cd.go.contrib.elasticagent.requests.StatusReportRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import freemarker.template.Template;
 import io.fabric8.kubernetes.api.model.NodeList;
@@ -72,9 +74,9 @@ public class StatusReportExecutorTest {
         final Template template = mock(Template.class);
 
         when(builder.getTemplate("status-report.template.ftlh")).thenReturn(template);
-        when(builder.build(eq(template), any(KubernetesCluster.class))).thenReturn("status-report");
+        when(builder.build(eq(template), any(StatusReportInformation.class))).thenReturn("status-report");
 
-        final GoPluginApiResponse response = new StatusReportExecutor(pluginRequest, kubernetesClientFactory, builder).execute();
+        final GoPluginApiResponse response = new StatusReportExecutor(new StatusReportRequest(), pluginRequest, kubernetesClientFactory, builder).execute();
 
         assertThat(response.responseCode(), is(200));
         assertThat(response.responseBody(), is("{\"view\":\"status-report\"}"));


### PR DESCRIPTION
* Highlight the pod running the job when jobIdentifier is provided as part of the get-status-report page
* Show normal status report page when no job-identifier is passed as part of the get-status-report request

More information: https://github.com/gocd/gocd/issues/4091\#issuecomment-352979314

![screen shot 2017-12-20 at 4 41 43 pm](https://user-images.githubusercontent.com/15275847/34204574-263abe62-e5a5-11e7-99de-54d7bcdd3109.png)
