### PR TITLE
Fix NullPointerException in server-ping request

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
@@ -68,11 +68,17 @@ public class KubernetesInstanceFactory {
 
         Pod elasticAgentPod = new Pod("v1", "Pod", podMetadata, podSpec, new PodStatus());
 
+        setGoCDMetadata(request, settings, pluginRequest, elasticAgentPod);
+
+        return createKubernetesPod(client, elasticAgentPod);
+    }
+
+    private void setGoCDMetadata(CreateAgentRequest request, PluginSettings settings, PluginRequest pluginRequest, Pod elasticAgentPod) {
+        elasticAgentPod.getMetadata().setCreationTimestamp(getSimpleDateFormat().format(new Date()));
+
         setContainerEnvVariables(elasticAgentPod, request, settings, pluginRequest);
         setAnnotations(elasticAgentPod, request);
         setLabels(elasticAgentPod, request);
-
-        return createKubernetesPod(client, elasticAgentPod);
     }
 
     private ResourceRequirements getPodResources(CreateAgentRequest request) {
@@ -210,12 +216,7 @@ public class KubernetesInstanceFactory {
             LOG.error(e.getMessage());
         }
 
-        elasticAgentPod.getMetadata().setCreationTimestamp(getSimpleDateFormat().format(new Date()));
-
-        setContainerEnvVariables(elasticAgentPod, request, settings, pluginRequest);
-        setAnnotations(elasticAgentPod, request);
-        setLabels(elasticAgentPod, request);
-
+        setGoCDMetadata(request, settings, pluginRequest, elasticAgentPod);
         return createKubernetesPod(client, elasticAgentPod);
     }
 

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesIntegrationTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesIntegrationTest.java
@@ -137,6 +137,18 @@ public class KubernetesAgentInstancesIntegrationTest {
     }
 
     @Test
+    public void shouldCreateKubernetesPodWithTimeStamp() throws Exception {
+        ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
+        kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+        verify(pods).create(argumentCaptor.capture());
+
+        Pod elasticAgentPod = argumentCaptor.getValue();
+
+        assertNotNull(elasticAgentPod.getMetadata());
+        assertNotNull(elasticAgentPod.getMetadata().getCreationTimestamp());
+    }
+
+    @Test
     public void shouldCreateKubernetesPodWithGoCDElasticAgentContainerContainingEnvironmentVariables() throws Exception {
         ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
         KubernetesInstance instance = kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
@@ -236,6 +248,20 @@ public class KubernetesAgentInstancesIntegrationTest {
         assertThat(elasticAgentPod.getMetadata().getName(), is("test-pod-yaml"));
 
         assertThat(elasticAgentPod.getMetadata().getName(), is(instance.name()));
+    }
+
+    @Test
+    public void usingPodYamlConfigurations_shouldCreateKubernetesPodWithTimestamp() throws Exception {
+        createAgentRequest = CreateAgentRequestMother.createAgentRequestUsingPodYaml();
+
+        ArgumentCaptor<Pod> argumentCaptor = ArgumentCaptor.forClass(Pod.class);
+        kubernetesAgentInstances.create(createAgentRequest, settings, mockedPluginRequest);
+        verify(pods).create(argumentCaptor.capture());
+
+        Pod elasticAgentPod = argumentCaptor.getValue();
+
+        assertNotNull(elasticAgentPod.getMetadata());
+        assertNotNull(elasticAgentPod.getMetadata().getCreationTimestamp());
     }
 
     @Test


### PR DESCRIPTION
* On Server Ping request, to find the gocd-agent-container creation time, pod creation timestamp is used, not setting pod creation timestamp throws a nullPointerException
* Specify pod creation timestamp for both pods created via configuration spec or via configuration yaml