### PR TITLE
Allow specifying templated values in elastic agent pod yaml

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
@@ -201,12 +201,7 @@ public class KubernetesInstanceFactory {
     private KubernetesInstance createUsingPodYaml(CreateAgentRequest request, PluginSettings settings, KubernetesClient client, PluginRequest pluginRequest) {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         String podYaml = request.properties().get(POD_CONFIGURATION.getKey());
-
-        StringWriter writer = new StringWriter();
-        MustacheFactory mf = new DefaultMustacheFactory();
-        Mustache mustache = mf.compile(new StringReader(podYaml), "templatePod");
-        mustache.execute(writer, KubernetesInstanceFactory.getJinJavaContext());
-        String templatizedPodYaml = writer.toString();
+        String templatizedPodYaml = getTemplatizedPodYamlString(podYaml);
 
         Pod elasticAgentPod = new Pod();
         try {
@@ -218,6 +213,14 @@ public class KubernetesInstanceFactory {
 
         setGoCDMetadata(request, settings, pluginRequest, elasticAgentPod);
         return createKubernetesPod(client, elasticAgentPod);
+    }
+
+    public static String getTemplatizedPodYamlString(String podYaml) {
+        StringWriter writer = new StringWriter();
+        MustacheFactory mf = new DefaultMustacheFactory();
+        Mustache mustache = mf.compile(new StringReader(podYaml), "templatePod");
+        mustache.execute(writer, KubernetesInstanceFactory.getJinJavaContext());
+        return writer.toString();
     }
 
     public static Map<String, String> getJinJavaContext() {

--- a/src/main/java/cd/go/contrib/elasticagent/executors/ProfileValidateRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagent/executors/ProfileValidateRequestExecutor.java
@@ -16,6 +16,7 @@
 
 package cd.go.contrib.elasticagent.executors;
 
+import cd.go.contrib.elasticagent.KubernetesInstanceFactory;
 import cd.go.contrib.elasticagent.RequestExecutor;
 import cd.go.contrib.elasticagent.model.Metadata;
 import cd.go.contrib.elasticagent.requests.ProfileValidateRequest;
@@ -96,7 +97,7 @@ public class ProfileValidateRequestExecutor implements RequestExecutor {
 
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         try {
-            mapper.readValue(podYaml, Pod.class);
+            mapper.readValue(KubernetesInstanceFactory.getTemplatizedPodYamlString(podYaml), Pod.class);
         } catch (IOException e) {
             addError(result, key, "Invalid Pod Yaml.");
         }

--- a/src/main/java/cd/go/contrib/elasticagent/executors/ValidateConfigurationExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagent/executors/ValidateConfigurationExecutor.java
@@ -22,7 +22,6 @@ import cd.go.contrib.elasticagent.ServerRequestFailedException;
 import cd.go.contrib.elasticagent.model.Field;
 import cd.go.contrib.elasticagent.model.ServerInfo;
 import cd.go.contrib.elasticagent.requests.ValidatePluginSettings;
-import com.google.gson.Gson;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import org.apache.commons.lang3.StringUtils;


### PR DESCRIPTION
[here](https://github.com/gocd/kubernetes-elastic-agents/compare/master...GaneshSPatil:allow-mustache-templated-values-in-elastic-profile-yaml-configuration?expand=1#diff-336e47716c6a57cb132d9bcd64ae5062R92) is an example of templated pod YAML