### PR TITLE
Remove JobID information from agent status report page

### DIFF
--- a/src/main/resources/agent-status-report.template.ftlh
+++ b/src/main/resources/agent-status-report.template.ftlh
@@ -248,7 +248,7 @@
 			<li class="job_label">
 				<span class="label">Job</span>
 				<a href="/go/tab/build/detail/${jobIdentifier.pipelineName!''}/${jobIdentifier.pipelineCounter!''}/${jobIdentifier.stageName!''}/${jobIdentifier.stageCounter!''}/${jobIdentifier.jobName!''}"
-				   title="View this job's details">${jobIdentifier.jobName!''}(${jobIdentifier.jobId!''})</a>
+				   title="View this job's details">${jobIdentifier.jobName!''}</a>
 			</li>
 
 			<li class="last">


### PR DESCRIPTION
* Fixes: https://github.com/gocd/gocd/issues/4486