### PR TITLE
Do not error out in case job cant be assigned on an elastic agent

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutor.java
@@ -49,7 +49,7 @@ public class ShouldAssignWorkRequestExecutor implements RequestExecutor {
             return DefaultGoPluginApiResponse.success("true");
         }
 
-        LOG.error(format("[should-assign-work] Job with identifier {0} can not be assigned to an agent {1}.", request.jobIdentifier(), pod.name()));
+        LOG.debug(format("[should-assign-work] Job with identifier {0} can not be assigned to an agent {1}.", request.jobIdentifier(), pod.name()));
         return DefaultGoPluginApiResponse.success("false");
     }
 }


### PR DESCRIPTION
Print DEBUG log instead of ERROR log if a job could not be assigned on an elastic agent