### PR TITLE
Fixed for #149:

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
@@ -119,8 +119,9 @@ public class KubernetesInstanceFactory {
         String maxMemory = request.properties().get("MaxMemory");
         if (StringUtils.isNotBlank(maxMemory)) {
             Size mem = Size.parse(maxMemory);
-            LOG.debug(format("[Create Agent] Setting memory resource limit on k8s pod: {0}.", new Quantity(valueOf(mem.toMegabytes()), "M")));
-            limits.put("memory", new Quantity(valueOf(mem.toBytes())));
+            LOG.debug(format("[Create Agent] Setting memory resource limit on k8s pod: {0}.", new Quantity(valueOf((long) mem.toMegabytes()), "M")));
+            long memory = (long) mem.toBytes();
+            limits.put("memory", new Quantity(valueOf(memory)));
         }
 
         String maxCPU = request.properties().get("MaxCPU");

--- a/src/main/java/cd/go/contrib/elasticagent/model/KubernetesNode.java
+++ b/src/main/java/cd/go/contrib/elasticagent/model/KubernetesNode.java
@@ -16,6 +16,7 @@
 
 package cd.go.contrib.elasticagent.model;
 
+import cd.go.contrib.elasticagent.utils.Size;
 import cd.go.contrib.elasticagent.utils.Util;
 import io.fabric8.kubernetes.api.model.Node;
 
@@ -47,13 +48,13 @@ public class KubernetesNode {
         nodeAddress = node.getStatus().getAddresses().get(0).getAddress();
 
         totalCPU = node.getStatus().getCapacity().get("cpu").getAmount();
-        String memory = node.getStatus().getCapacity().get("memory").getAmount();
-        totalMemory = Util.readableSize(Long.valueOf(memory.replace("Ki", "")));
+        Size mem = Size.parse(node.getStatus().getCapacity().get("memory").getAmount());
+        totalMemory = mem.readableSize();
         totalPods = node.getStatus().getCapacity().get("pods").getAmount();
 
         allocatableCPU = node.getStatus().getAllocatable().get("cpu").getAmount();
         String allocatableMemory = node.getStatus().getAllocatable().get("memory").getAmount();
-        this.allocatableMemory = Util.readableSize(Long.valueOf(allocatableMemory.replace("Ki", "")));
+        this.allocatableMemory = Size.parse(allocatableMemory).readableSize();
         allocatablePods = node.getStatus().getAllocatable().get("pods").getAmount();
 
         osImage = node.getStatus().getNodeInfo().getOsImage();

--- a/src/main/java/cd/go/contrib/elasticagent/utils/SizeUnit.java
+++ b/src/main/java/cd/go/contrib/elasticagent/utils/SizeUnit.java
@@ -55,7 +55,7 @@ public enum SizeUnit {
      * @param unit the unit of the size
      * @return the given size in the current unit.
      */
-    public long convert(long size, SizeUnit unit) {
+    public double convert(double size, SizeUnit unit) {
         return (size * unit.bits) / bits;
     }
 
@@ -65,7 +65,7 @@ public enum SizeUnit {
      * @param l the magnitude of the size in the current unit
      * @return {@code l} of the current units in bytes
      */
-    public long toBytes(long l) {
+    public double toBytes(double l) {
         return BYTES.convert(l, this);
     }
 
@@ -75,7 +75,7 @@ public enum SizeUnit {
      * @param l the magnitude of the size in the current unit
      * @return {@code l} of the current units in kilobytes
      */
-    public long toKilobytes(long l) {
+    public double toKilobytes(double l) {
         return KILOBYTES.convert(l, this);
     }
 
@@ -85,7 +85,7 @@ public enum SizeUnit {
      * @param l the magnitude of the size in the current unit
      * @return {@code l} of the current units in megabytes
      */
-    public long toMegabytes(long l) {
+    public double toMegabytes(double l) {
         return MEGABYTES.convert(l, this);
     }
 
@@ -95,7 +95,7 @@ public enum SizeUnit {
      * @param l the magnitude of the size in the current unit
      * @return {@code l} of the current units in bytes
      */
-    public long toGigabytes(long l) {
+    public double toGigabytes(double l) {
         return GIGABYTES.convert(l, this);
     }
 
@@ -105,7 +105,7 @@ public enum SizeUnit {
      * @param l the magnitude of the size in the current unit
      * @return {@code l} of the current units in terabytes
      */
-    public long toTerabytes(long l) {
+    public double toTerabytes(double l) {
         return TERABYTES.convert(l, this);
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagent/utils/Util.java
+++ b/src/main/java/cd/go/contrib/elasticagent/utils/Util.java
@@ -89,14 +89,6 @@ public class Util {
         }
     }
 
-    public static String readableSize(Long memory) {
-        Long size = memory * 1024;
-        if (size <= 0) return "0";
-        final String[] units = new String[]{"B", "KB", "MB", "GB", "TB", "PB", "EB"};
-        int digitGroups = (int) (Math.log10(size) / Math.log10(1024));
-        return new DecimalFormat("#,##0.##").format(size / Math.pow(1024, digitGroups)) + " " + units[digitGroups];
-    }
-
     public static TypeAdapter<Number> IntTypeAdapter = new TypeAdapter<Number>() {
 
         @Override

--- a/src/test/java/cd/go/contrib/elasticagent/utils/SizeTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/utils/SizeTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.contrib.elasticagent.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class SizeTest {
+
+    @Test
+    public void shouldParseTheGivenSize() {
+        Size parse = Size.parse("24000ki");
+        assertEquals(parse.getUnit(), SizeUnit.KILOBYTES);
+        assertEquals(parse.getQuantity(), 24000, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfTheGivenSizeHasDifferentSuffix() {
+        Size parse = Size.parse("24000kig");
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfTheGivenSizeHasNoUint() {
+        Size parse = Size.parse("24000");
+    }
+
+    @Test
+    public void toBytes() {
+        Size oneKB = Size.parse("1Ki");
+        assertEquals(oneKB.toBytes(), 1024, 0);
+    }
+
+    @Test
+    public void toKilobytes() {
+        Size size = Size.parse("12000B");
+        assertEquals(size.toKilobytes(), 11.72, 0.01);
+    }
+
+    @Test
+    public void toMegabytes() {
+        Size size = Size.parse("12000KiB");
+        assertEquals(size.toMegabytes(), 11.72, 0.01);
+    }
+
+    @Test
+    public void toGigabytes() {
+        Size size = Size.parse("1200000KiB");
+        assertEquals(size.toGigabytes(), 1.14, 0.01);
+    }
+
+    @Test
+    public void toTerabytes() {
+        Size size = Size.parse("1456823212Mi");
+        assertEquals(size.toTerabytes(), 1389.33, 0.01);
+    }
+
+    @Test
+    public void readableSize() {
+        Size size = Size.parse("1024Mi");
+        Size sizeInKB = Size.parse("10256KiB");
+        assertEquals(size.readableSize(),"1 GB");
+        assertEquals(sizeInKB.readableSize(),"10.02 MB");
+    }
+}


### PR DESCRIPTION
Issue : #149

While initializing Kubernetes node, total memory and allocatable memory were converted to readable format considering the unit as `Ki`.
The unit for memory can be `Ki`, `Mi`, `Gi`, `Ti` etc.
Updated the code to convert memory to readable format considering these units.

As part of this fix, following changes were made
  - Moved the readableSize method to Size class. Reused Size class.
  - Updated `count` in `Size` class from long to `double`. This change
  is done to get precision upto two decimal places while converting
  memory size to any other unit.