### PR TITLE
log message formatter

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagent/executors/CreateAgentRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagent/executors/CreateAgentRequestExecutor.java
@@ -51,7 +51,7 @@ public class CreateAgentRequestExecutor implements RequestExecutor {
         try {
             agentInstances.create(request, request.clusterProfileProperties(), pluginRequest, consoleLogAppender);
         } catch (Exception e) {
-            consoleLogAppender.accept(format("Failed to create agent pod: %s", e.getMessage()));
+            consoleLogAppender.accept(String.format("Failed to create agent pod: %s", e.getMessage()));
             throw e;
         }
 


### PR DESCRIPTION
Wasn't able to catch this on this commit 3a5b202. 

Using `String.format` instead of `MessageFormat.format`

![Screen Shot 2020-01-31 at 12 45 19 PM](https://user-images.githubusercontent.com/10841489/73524392-ff9bf880-4447-11ea-9f7b-691d7a7b8a4a.png)