### PR TITLE
Fix max memory error while creating elastic profile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply from: "https://raw.githubusercontent.com/gocd/gocd-plugin-gradle-task-help
 
 gocdPlugin {
   id = 'cd.go.contrib.elasticagent.kubernetes'
-  pluginVersion = '3.7.0'
+  pluginVersion = '3.7.1'
   goCdVersion = '19.3.0'
   name = 'Kubernetes Elastic Agent Plugin'
   description = 'Kubernetes Based Elastic Agent Plugins for GoCD'

--- a/src/main/java/cd/go/contrib/elasticagent/utils/Size.java
+++ b/src/main/java/cd/go/contrib/elasticagent/utils/Size.java
@@ -17,6 +17,7 @@
 package cd.go.contrib.elasticagent.utils;
 
 import com.google.common.collect.ImmutableSortedMap;
+import org.apache.commons.lang3.StringUtils;
 
 import java.text.DecimalFormat;
 import java.util.Locale;
@@ -89,6 +90,9 @@ public class Size implements Comparable<Size> {
     }
 
     public static Size parse(String size) {
+        if (StringUtils.isBlank(size)) {
+            throw new IllegalArgumentException();
+        }
         final Matcher matcher = SIZE_PATTERN.matcher(size);
         checkArgument(matcher.matches(), "Invalid size: " + size);
 

--- a/src/test/java/cd/go/contrib/elasticagent/utils/SizeTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/utils/SizeTest.java
@@ -19,7 +19,6 @@ package cd.go.contrib.elasticagent.utils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class SizeTest {
 
@@ -35,10 +34,19 @@ public class SizeTest {
         Size parse = Size.parse("24000kig");
     }
 
-
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowExceptionIfTheGivenSizeHasNoUint() {
         Size parse = Size.parse("24000");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfTheGivenSizeIsNull() {
+        Size.parse(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfTheGivenSizeIsBlank() {
+        Size.parse("");
     }
 
     @Test
@@ -75,7 +83,7 @@ public class SizeTest {
     public void readableSize() {
         Size size = Size.parse("1024Mi");
         Size sizeInKB = Size.parse("10256KiB");
-        assertEquals(size.readableSize(),"1 GB");
-        assertEquals(sizeInKB.readableSize(),"10.02 MB");
+        assertEquals(size.readableSize(), "1 GB");
+        assertEquals(sizeInKB.readableSize(), "10.02 MB");
     }
 }


### PR DESCRIPTION
GoCD issue: https://github.com/gocd/gocd/issues/8201

Due to changes in gocd - "" string is now send instead of null values which caused incorrect max memory error.

This commit throws an IllegalArgumentException is null or blank string is received while parsing for size.