### PR TITLE
Migrate to JUnit5 with AssertJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,11 +62,17 @@ dependencies {
     implementation group: 'org.freemarker', name: 'freemarker', version: '2.3.31'
 
     testImplementation group: 'cd.go.plugin', name: 'go-plugin-api', version: '21.4.0'
-    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.2'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.8.2'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.8.2'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.8.2'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.21.0'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.2.0'
     testImplementation group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.0'
     testImplementation group: 'org.jsoup', name: 'jsoup', version: '1.14.3'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 jar {

--- a/src/test/java/cd/go/contrib/elasticagent/AgentTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/AgentTest.java
@@ -16,16 +16,15 @@
 
 package cd.go.contrib.elasticagent;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 
 public class AgentTest {
@@ -41,14 +40,14 @@ public class AgentTest {
     @Test
     public void shouldDeserializeFromJSON() throws Exception {
         List<Agent> agents = Agent.fromJSONArray("[{\"agent_id\":\"eeb9e0eb-1f12-4366-a5a5-59011810273b\",\"agent_state\":\"Building\",\"build_state\":\"Cancelled\",\"config_state\":\"Disabled\"}]");
-        assertThat(agents, hasSize(1));
+        assertThat(agents).hasSize(1);
 
         Agent agent = agents.get(0);
 
-        assertThat(agent.elasticAgentId(), is("eeb9e0eb-1f12-4366-a5a5-59011810273b"));
-        assertThat(agent.agentState(), is(Agent.AgentState.Building));
-        assertThat(agent.buildState(), is(Agent.BuildState.Cancelled));
-        assertThat(agent.configState(), is(Agent.ConfigState.Disabled));
+        assertThat(agent.elasticAgentId()).isEqualTo("eeb9e0eb-1f12-4366-a5a5-59011810273b");
+        assertThat(agent.agentState()).isEqualTo(Agent.AgentState.Building);
+        assertThat(agent.buildState()).isEqualTo(Agent.BuildState.Cancelled);
+        assertThat(agent.configState()).isEqualTo(Agent.ConfigState.Disabled);
     }
 
     @Test
@@ -56,21 +55,21 @@ public class AgentTest {
         Agent agent1 = new Agent("eeb9e0eb-1f12-4366-a5a5-59011810273b", Agent.AgentState.Building, Agent.BuildState.Cancelled, Agent.ConfigState.Disabled);
         Agent agent2 = new Agent("eeb9e0eb-1f12-4366-a5a5-59011810273b", Agent.AgentState.Building, Agent.BuildState.Cancelled, Agent.ConfigState.Disabled);
 
-        assertTrue(agent1.equals(agent2));
+        assertEquals(agent1, agent2);
     }
 
     @Test
     public void agentShouldEqualItself() throws Exception {
         Agent agent = new Agent("eeb9e0eb-1f12-4366-a5a5-59011810273b", Agent.AgentState.Building, Agent.BuildState.Cancelled, Agent.ConfigState.Disabled);
 
-        assertTrue(agent.equals(agent));
+        assertEquals(agent, agent);
     }
 
     @Test
     public void agentShouldNotEqualAnotherAgentWithDifferentAttributes() throws Exception {
         Agent agent = new Agent("eeb9e0eb-1f12-4366-a5a5-59011810273b", Agent.AgentState.Building, Agent.BuildState.Cancelled, Agent.ConfigState.Disabled);
 
-        assertFalse(agent.equals(new Agent()));
+        assertNotEquals(agent, new Agent());
     }
 
     @Test
@@ -78,7 +77,7 @@ public class AgentTest {
         Agent agent1 = new Agent("eeb9e0eb-1f12-4366-a5a5-59011810273b", Agent.AgentState.Building, Agent.BuildState.Cancelled, Agent.ConfigState.Disabled);
         Agent agent2 = new Agent("eeb9e0eb-1f12-4366-a5a5-59011810273b", Agent.AgentState.Building, Agent.BuildState.Cancelled, Agent.ConfigState.Disabled);
 
-        assertThat(agent1.hashCode(), equalTo(agent2.hashCode()));
+        assertThat(agent1.hashCode()).isEqualTo(agent2.hashCode());
     }
 
     @Test
@@ -86,6 +85,6 @@ public class AgentTest {
         Agent agent1 = new Agent("eeb9e0eb-1f12-4366-a5a5-59011810273b", Agent.AgentState.Building, Agent.BuildState.Cancelled, Agent.ConfigState.Disabled);
         Agent agent2 = new Agent();
 
-        assertThat(agent1.hashCode(), not(equalTo(agent2.hashCode())));
+        assertThat(agent1.hashCode()).isNotEqualTo(agent2.hashCode());
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/ClusterProfilePropertiesTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/ClusterProfilePropertiesTest.java
@@ -18,12 +18,12 @@ package cd.go.contrib.elasticagent;
 
 import cd.go.contrib.elasticagent.requests.CreateAgentRequest;
 import cd.go.contrib.elasticagent.requests.ShouldAssignWorkRequest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class ClusterProfilePropertiesTest {
     @Test
@@ -32,7 +32,7 @@ public class ClusterProfilePropertiesTest {
         clusterProfileConfigurations.put("go_server_url", "go-server-url");
         ClusterProfileProperties profileProperties = ClusterProfileProperties.fromConfiguration(clusterProfileConfigurations);
 
-        assertThat(profileProperties.uuid(), is(profileProperties.uuid()));
+        assertThat(profileProperties.uuid()).isEqualTo(profileProperties.uuid());
     }
 
     @Test
@@ -87,6 +87,6 @@ public class ClusterProfilePropertiesTest {
                 "}";
 
         ShouldAssignWorkRequest shouldAssignWorkRequest = ShouldAssignWorkRequest.fromJSON(shouldAssignWorkJSON);
-        assertThat(createAgentRequest.clusterProfileProperties().uuid(), is(shouldAssignWorkRequest.clusterProfileProperties().uuid()));
+        assertThat(createAgentRequest.clusterProfileProperties().uuid()).isEqualTo(shouldAssignWorkRequest.clusterProfileProperties().uuid());
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesIntegrationTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesIntegrationTest.java
@@ -22,9 +22,9 @@ import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationsImpl;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
@@ -36,13 +36,13 @@ import java.util.List;
 import java.util.Map;
 
 import static cd.go.contrib.elasticagent.executors.GetProfileMetadataExecutor.PRIVILEGED;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class KubernetesAgentInstancesIntegrationTest {
 
@@ -65,9 +65,9 @@ public class KubernetesAgentInstancesIntegrationTest {
     @Mock
     private ConsoleLogAppender consoleLogAppender;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
+        openMocks(this);
         kubernetesAgentInstances = new KubernetesAgentInstances(mockedKubernetesClientFactory);
         when(mockedKubernetesClientFactory.client(any())).thenReturn(mockKubernetesClient);
         when(pods.create(any())).thenAnswer((Answer<Pod>) invocation -> {
@@ -82,7 +82,7 @@ public class KubernetesAgentInstancesIntegrationTest {
         settings = PluginSettingsMother.defaultPluginSettings();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         FileUtils.deleteQuietly(new File("pod_spec"));
     }
@@ -102,15 +102,15 @@ public class KubernetesAgentInstancesIntegrationTest {
         Pod elasticAgentPod = argumentCaptor.getValue();
 
         List<Container> containers = elasticAgentPod.getSpec().getContainers();
-        assertThat(containers.size(), is(1));
+        assertThat(containers.size()).isEqualTo(1);
 
         Container gocdAgentContainer = containers.get(0);
 
-        assertThat(gocdAgentContainer.getName(), is(instance.name()));
+        assertThat(gocdAgentContainer.getName()).isEqualTo(instance.name());
 
-        assertThat(gocdAgentContainer.getImage(), is("gocd/custom-gocd-agent-alpine:latest"));
-        assertThat(gocdAgentContainer.getImagePullPolicy(), is("IfNotPresent"));
-        assertThat(gocdAgentContainer.getSecurityContext().getPrivileged(), is(false));
+        assertThat(gocdAgentContainer.getImage()).isEqualTo("gocd/custom-gocd-agent-alpine:latest");
+        assertThat(gocdAgentContainer.getImagePullPolicy()).isEqualTo("IfNotPresent");
+        assertThat(gocdAgentContainer.getSecurityContext().getPrivileged()).isEqualTo(false);
     }
 
     @Test
@@ -122,12 +122,12 @@ public class KubernetesAgentInstancesIntegrationTest {
         Pod elasticAgentPod = argumentCaptor.getValue();
 
         List<Container> containers = elasticAgentPod.getSpec().getContainers();
-        assertThat(containers.size(), is(1));
+        assertThat(containers.size()).isEqualTo(1);
 
         Container gocdAgentContainer = containers.get(0);
 
-        assertThat(gocdAgentContainer.getName(), is(instance.name()));
-        assertThat(gocdAgentContainer.getSecurityContext().getPrivileged(), is(true));
+        assertThat(gocdAgentContainer.getName()).isEqualTo(instance.name());
+        assertThat(gocdAgentContainer.getSecurityContext().getPrivileged()).isEqualTo(true);
     }
 
     @Test
@@ -138,14 +138,14 @@ public class KubernetesAgentInstancesIntegrationTest {
         Pod elasticAgentPod = argumentCaptor.getValue();
 
         List<Container> containers = elasticAgentPod.getSpec().getContainers();
-        assertThat(containers.size(), is(1));
+        assertThat(containers.size()).isEqualTo(1);
 
         Container gocdAgentContainer = containers.get(0);
 
         ResourceRequirements resources = gocdAgentContainer.getResources();
 
-        assertThat(resources.getLimits().get("memory").getAmount(), is(String.valueOf(1024 * 1024 * 1024)));
-        assertThat(resources.getLimits().get("cpu").getAmount(), is("2"));
+        assertThat(resources.getLimits().get("memory").getAmount()).isEqualTo(String.valueOf(1024 * 1024 * 1024));
+        assertThat(resources.getLimits().get("cpu").getAmount()).isEqualTo("2");
     }
 
     @Test
@@ -157,7 +157,7 @@ public class KubernetesAgentInstancesIntegrationTest {
         Pod elasticAgentPod = argumentCaptor.getValue();
 
         assertNotNull(elasticAgentPod.getMetadata());
-        assertThat(elasticAgentPod.getMetadata().getName(), is(instance.name()));
+        assertThat(elasticAgentPod.getMetadata().getName()).isEqualTo(instance.name());
     }
 
     @Test
@@ -191,9 +191,9 @@ public class KubernetesAgentInstancesIntegrationTest {
         expectedEnvVars.add(new EnvVar("GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID", Constants.PLUGIN_ID, null));
 
         List<Container> containers = elasticAgentPod.getSpec().getContainers();
-        assertThat(containers.size(), is(1));
+        assertThat(containers.size()).isEqualTo(1);
 
-        assertThat(containers.get(0).getEnv(), is(expectedEnvVars));
+        assertThat(containers.get(0).getEnv()).isEqualTo(expectedEnvVars);
     }
 
     @Test
@@ -208,7 +208,7 @@ public class KubernetesAgentInstancesIntegrationTest {
         Map<String, String> expectedAnnotations = new HashMap<>();
         expectedAnnotations.putAll(createAgentRequest.properties());
         expectedAnnotations.put(Constants.JOB_IDENTIFIER_LABEL_KEY, new Gson().toJson(createAgentRequest.jobIdentifier()));
-        assertThat(elasticAgentPod.getMetadata().getAnnotations(), is(expectedAnnotations));
+        assertThat(elasticAgentPod.getMetadata().getAnnotations()).isEqualTo(expectedAnnotations);
     }
 
     @Test
@@ -226,7 +226,7 @@ public class KubernetesAgentInstancesIntegrationTest {
         labels.put(Constants.KUBERNETES_POD_KIND_LABEL_KEY, Constants.KUBERNETES_POD_KIND_LABEL_VALUE);
         labels.put(Constants.ENVIRONMENT_LABEL_KEY, createAgentRequest.environment());
 
-        assertThat(elasticAgentPod.getMetadata().getLabels(), is(labels));
+        assertThat(elasticAgentPod.getMetadata().getLabels()).isEqualTo(labels);
     }
 
     //Tests Using Pod Yaml
@@ -249,13 +249,13 @@ public class KubernetesAgentInstancesIntegrationTest {
         Pod elasticAgentPod = argumentCaptor.getValue();
 
         List<Container> containers = elasticAgentPod.getSpec().getContainers();
-        assertThat(containers.size(), is(1));
+        assertThat(containers.size()).isEqualTo(1);
 
         Container gocdAgentContainer = containers.get(0);
 
-        assertThat(gocdAgentContainer.getName(), is("gocd-agent-container"));
-        assertThat(gocdAgentContainer.getImage(), is("gocd/gocd-agent-alpine-3.5:v17.12.0"));
-        assertThat(gocdAgentContainer.getImagePullPolicy(), is("Always"));
+        assertThat(gocdAgentContainer.getName()).isEqualTo("gocd-agent-container");
+        assertThat(gocdAgentContainer.getImage()).isEqualTo("gocd/gocd-agent-alpine-3.5:v17.12.0");
+        assertThat(gocdAgentContainer.getImagePullPolicy()).isEqualTo("Always");
     }
 
     @Test
@@ -269,9 +269,9 @@ public class KubernetesAgentInstancesIntegrationTest {
         Pod elasticAgentPod = argumentCaptor.getValue();
 
         assertNotNull(elasticAgentPod.getMetadata());
-        assertThat(elasticAgentPod.getMetadata().getName(), containsString("test-pod-yaml"));
+        assertThat(elasticAgentPod.getMetadata().getName()).contains("test-pod-yaml");
 
-        assertThat(elasticAgentPod.getMetadata().getName(), is(instance.name()));
+        assertThat(elasticAgentPod.getMetadata().getName()).isEqualTo(instance.name());
     }
 
     @Test
@@ -307,9 +307,9 @@ public class KubernetesAgentInstancesIntegrationTest {
         expectedEnvVars.add(new EnvVar("GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID", Constants.PLUGIN_ID, null));
 
         List<Container> containers = elasticAgentPod.getSpec().getContainers();
-        assertThat(containers.size(), is(1));
+        assertThat(containers.size()).isEqualTo(1);
 
-        assertThat(containers.get(0).getEnv(), is(expectedEnvVars));
+        assertThat(containers.get(0).getEnv()).isEqualTo(expectedEnvVars);
     }
 
     @Test
@@ -328,7 +328,7 @@ public class KubernetesAgentInstancesIntegrationTest {
         expectedAnnotations.put("annotation-key", "my-fancy-annotation-value");
         expectedAnnotations.put(Constants.JOB_IDENTIFIER_LABEL_KEY, new Gson().toJson(createAgentRequest.jobIdentifier()));
 
-        assertThat(elasticAgentPod.getMetadata().getAnnotations(), is(expectedAnnotations));
+        assertThat(elasticAgentPod.getMetadata().getAnnotations()).isEqualTo(expectedAnnotations);
     }
 
     @Test
@@ -350,7 +350,7 @@ public class KubernetesAgentInstancesIntegrationTest {
 
         labels.put("app", "gocd-agent");
 
-        assertThat(elasticAgentPod.getMetadata().getLabels(), is(labels));
+        assertThat(elasticAgentPod.getMetadata().getLabels()).isEqualTo(labels);
     }
 
     //Tests Using Remote File
@@ -373,13 +373,13 @@ public class KubernetesAgentInstancesIntegrationTest {
         Pod elasticAgentPod = argumentCaptor.getValue();
 
         List<Container> containers = elasticAgentPod.getSpec().getContainers();
-        assertThat(containers.size(), is(1));
+        assertThat(containers.size()).isEqualTo(1);
 
         Container gocdAgentContainer = containers.get(0);
 
-        assertThat(gocdAgentContainer.getName(), is("gocd-agent-container"));
-        assertThat(gocdAgentContainer.getImage(), is("gocd/gocd-agent-alpine-3.8:v19.1.0"));
-        assertThat(gocdAgentContainer.getImagePullPolicy(), is("Always"));
+        assertThat(gocdAgentContainer.getName()).isEqualTo("gocd-agent-container");
+        assertThat(gocdAgentContainer.getImage()).isEqualTo("gocd/gocd-agent-alpine-3.8:v19.1.0");
+        assertThat(gocdAgentContainer.getImagePullPolicy()).isEqualTo("Always");
     }
 
     @Test
@@ -393,9 +393,9 @@ public class KubernetesAgentInstancesIntegrationTest {
         Pod elasticAgentPod = argumentCaptor.getValue();
 
         assertNotNull(elasticAgentPod.getMetadata());
-        assertThat(elasticAgentPod.getMetadata().getName(), containsString("test-pod-json"));
+        assertThat(elasticAgentPod.getMetadata().getName()).contains("test-pod-json");
 
-        assertThat(elasticAgentPod.getMetadata().getName(), is(instance.name()));
+        assertThat(elasticAgentPod.getMetadata().getName()).isEqualTo(instance.name());
     }
 
     @Test
@@ -431,9 +431,9 @@ public class KubernetesAgentInstancesIntegrationTest {
         expectedEnvVars.add(new EnvVar("GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID", Constants.PLUGIN_ID, null));
 
         List<Container> containers = elasticAgentPod.getSpec().getContainers();
-        assertThat(containers.size(), is(1));
+        assertThat(containers.size()).isEqualTo(1);
 
-        assertThat(containers.get(0).getEnv(), is(expectedEnvVars));
+        assertThat(containers.get(0).getEnv()).isEqualTo(expectedEnvVars);
     }
 
     @Test
@@ -452,7 +452,7 @@ public class KubernetesAgentInstancesIntegrationTest {
         expectedAnnotations.put("annotation-key", "my-fancy-annotation-value");
         expectedAnnotations.put(Constants.JOB_IDENTIFIER_LABEL_KEY, new Gson().toJson(createAgentRequest.jobIdentifier()));
 
-        assertThat(elasticAgentPod.getMetadata().getAnnotations(), is(expectedAnnotations));
+        assertThat(elasticAgentPod.getMetadata().getAnnotations()).isEqualTo(expectedAnnotations);
     }
 
     @Test
@@ -474,7 +474,7 @@ public class KubernetesAgentInstancesIntegrationTest {
 
         labels.put("app", "gocd-agent");
 
-        assertThat(elasticAgentPod.getMetadata().getLabels(), is(labels));
+        assertThat(elasticAgentPod.getMetadata().getLabels()).isEqualTo(labels);
     }
 
 }

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesTest.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 
@@ -38,10 +38,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static cd.go.contrib.elasticagent.Constants.JOB_ID_LABEL_KEY;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class KubernetesAgentInstancesTest {
     @Mock
@@ -73,9 +73,9 @@ public class KubernetesAgentInstancesTest {
 
     private HashMap<String, String> testProperties;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
+        openMocks(this);
         testProperties = new HashMap<>();
         when(mockCreateAgentRequest.properties()).thenReturn(testProperties);
         when(mockPluginSettings.getMaxPendingPods()).thenReturn(10);

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesClientFactoryTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesClientFactoryTest.java
@@ -19,22 +19,22 @@ package cd.go.contrib.elasticagent;
 import com.google.gson.Gson;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static cd.go.contrib.elasticagent.KubernetesClientFactory.CLIENT_RECYCLE_SYSTEM_PROPERTY_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class KubernetesClientFactoryTest {
     private PluginSettings pluginSettings;
     private KubernetesClientFactory factory;
     private Clock.TestClock clock;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         System.clearProperty(CLIENT_RECYCLE_SYSTEM_PROPERTY_KEY);
         final Map<String, Object> pluginSettingsMap = new HashMap<>();

--- a/src/test/java/cd/go/contrib/elasticagent/PluginRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/PluginRequestTest.java
@@ -19,7 +19,7 @@ package cd.go.contrib.elasticagent;
 import cd.go.contrib.elasticagent.model.JobIdentifier;
 import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
 import com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/cd/go/contrib/elasticagent/PluginSettingsTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/PluginSettingsTest.java
@@ -17,14 +17,13 @@
 package cd.go.contrib.elasticagent;
 
 import com.google.gson.Gson;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class PluginSettingsTest {
 
@@ -41,13 +40,13 @@ public class PluginSettingsTest {
 
         PluginSettings pluginSettings = PluginSettings.fromJSON(new Gson().toJson(pluginSettingsMap));
 
-        assertThat(pluginSettings.getGoServerUrl(), is("https://foo.go.cd/go"));
-        assertThat(pluginSettings.getAutoRegisterTimeout(), is(13));
-        assertThat(pluginSettings.getMaxPendingPods(), is(14));
-        assertThat(pluginSettings.getClusterUrl(), is("https://cloud.example.com"));
-        assertThat(pluginSettings.getCaCertData(), is("foo-ca-certs"));
-        assertThat(pluginSettings.getSecurityToken(), is("foo-token"));
-        assertThat(pluginSettings.getNamespace(), is("gocd"));
+        assertThat(pluginSettings.getGoServerUrl()).isEqualTo("https://foo.go.cd/go");
+        assertThat(pluginSettings.getAutoRegisterTimeout()).isEqualTo(13);
+        assertThat(pluginSettings.getMaxPendingPods()).isEqualTo(14);
+        assertThat(pluginSettings.getClusterUrl()).isEqualTo("https://cloud.example.com");
+        assertThat(pluginSettings.getCaCertData()).isEqualTo("foo-ca-certs");
+        assertThat(pluginSettings.getSecurityToken()).isEqualTo("foo-token");
+        assertThat(pluginSettings.getNamespace()).isEqualTo("gocd");
 
     }
 
@@ -64,13 +63,13 @@ public class PluginSettingsTest {
 
         PluginSettings pluginSettings = PluginSettings.fromJSON(new Gson().toJson(pluginSettingsMap));
 
-        assertThat(pluginSettings.getGoServerUrl(), is("https://foo.go.cd/go"));
-        assertThat(pluginSettings.getAutoRegisterTimeout(), is(10));
-        assertThat(pluginSettings.getMaxPendingPods(), is(10));
-        assertThat(pluginSettings.getClusterUrl(), is("https://cloud.example.com"));
-        assertThat(pluginSettings.getCaCertData(), is("foo-ca-certs"));
-        assertThat(pluginSettings.getSecurityToken(), is("foo-token"));
-        assertThat(pluginSettings.getNamespace(), is("gocd"));
+        assertThat(pluginSettings.getGoServerUrl()).isEqualTo("https://foo.go.cd/go");
+        assertThat(pluginSettings.getAutoRegisterTimeout()).isEqualTo(10);
+        assertThat(pluginSettings.getMaxPendingPods()).isEqualTo(10);
+        assertThat(pluginSettings.getClusterUrl()).isEqualTo("https://cloud.example.com");
+        assertThat(pluginSettings.getCaCertData()).isEqualTo("foo-ca-certs");
+        assertThat(pluginSettings.getSecurityToken()).isEqualTo("foo-token");
+        assertThat(pluginSettings.getNamespace()).isEqualTo("gocd");
     }
 
     @Test
@@ -78,9 +77,9 @@ public class PluginSettingsTest {
         PluginSettings pluginSettings = PluginSettings.fromJSON("{}");
 
         assertNull(pluginSettings.getGoServerUrl());
-        assertThat(pluginSettings.getAutoRegisterTimeout(), is(10));
-        assertThat(pluginSettings.getMaxPendingPods(), is(10));
-        assertThat(pluginSettings.getNamespace(), is("default"));
+        assertThat(pluginSettings.getAutoRegisterTimeout()).isEqualTo(10);
+        assertThat(pluginSettings.getMaxPendingPods()).isEqualTo(10);
+        assertThat(pluginSettings.getNamespace()).isEqualTo("default");
         assertNull(pluginSettings.getClusterUrl());
         assertNull(pluginSettings.getCaCertData());
     }
@@ -92,6 +91,6 @@ public class PluginSettingsTest {
 
         PluginSettings pluginSettings = PluginSettings.fromJSON(new Gson().toJson(pluginSettingsMap));
 
-        assertThat(pluginSettings.getNamespace(), is("default"));
+        assertThat(pluginSettings.getNamespace()).isEqualTo("default");
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/builders/PluginStatusReportViewBuilderTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/builders/PluginStatusReportViewBuilderTest.java
@@ -24,14 +24,13 @@ import freemarker.template.TemplateException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Date;
 
 import static java.util.Collections.singletonList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,7 +56,7 @@ public class PluginStatusReportViewBuilderTest {
     Element link = document.selectFirst("tbody tr td a");
     System.out.println(link);
 
-    assertThat(link.attr("href"), is("/go/admin/status_reports/cd.go.contrib.elastic.agent.kubernetes/agent/?job_id=3243546575676657"));
+    assertThat(link.attr("href")).isEqualTo("/go/admin/status_reports/cd.go.contrib.elastic.agent.kubernetes/agent/?job_id=3243546575676657");
   }
 
 }

--- a/src/test/java/cd/go/contrib/elasticagent/executors/AgentStatusReportExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/AgentStatusReportExecutorTest.java
@@ -19,7 +19,6 @@ package cd.go.contrib.elasticagent.executors;
 import cd.go.contrib.elasticagent.ClusterProfileProperties;
 import cd.go.contrib.elasticagent.KubernetesClientFactory;
 import cd.go.contrib.elasticagent.PluginRequest;
-import cd.go.contrib.elasticagent.PluginSettings;
 import cd.go.contrib.elasticagent.builders.PluginStatusReportViewBuilder;
 import cd.go.contrib.elasticagent.model.JobIdentifier;
 import cd.go.contrib.elasticagent.model.reports.agent.KubernetesElasticAgent;
@@ -33,8 +32,8 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.util.ArrayList;
@@ -42,12 +41,11 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static cd.go.contrib.elasticagent.Constants.JOB_IDENTIFIER_LABEL_KEY;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class AgentStatusReportExecutorTest {
 
@@ -93,9 +91,9 @@ public class AgentStatusReportExecutorTest {
     @Mock
     private Template template;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
+        openMocks(this);
         Pod pod = createDefaultPod();
         pod.getMetadata().setName(elasticAgentId);
         executor = new AgentStatusReportExecutor(statusReportRequest, kubernetesClientFactory, builder);
@@ -130,8 +128,8 @@ public class AgentStatusReportExecutorTest {
 
         GoPluginApiResponse response = executor.execute();
 
-        assertThat(response.responseCode(), is(200));
-        assertThat(response.responseBody(), is("{\"view\":\"my-view\"}"));
+        assertThat(response.responseCode()).isEqualTo(200);
+        assertThat(response.responseBody()).isEqualTo("{\"view\":\"my-view\"}");
     }
 
     @Test
@@ -151,8 +149,8 @@ public class AgentStatusReportExecutorTest {
 
         GoPluginApiResponse response = executor.execute();
 
-        assertThat(response.responseCode(), is(200));
-        assertThat(response.responseBody(), is("{\"view\":\"my-error-view\"}"));
+        assertThat(response.responseCode()).isEqualTo(200);
+        assertThat(response.responseBody()).isEqualTo("{\"view\":\"my-error-view\"}");
     }
 
     @Test
@@ -173,8 +171,8 @@ public class AgentStatusReportExecutorTest {
 
         GoPluginApiResponse response = executor.execute();
 
-        assertThat(response.responseCode(), is(200));
-        assertThat(response.responseBody(), is("{\"view\":\"my-error-view\"}"));
+        assertThat(response.responseCode()).isEqualTo(200);
+        assertThat(response.responseBody()).isEqualTo("{\"view\":\"my-error-view\"}");
     }
 
     private Pod createDefaultPod() {

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ClusterProfileValidateRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ClusterProfileValidateRequestExecutorTest.java
@@ -19,7 +19,7 @@ package cd.go.contrib.elasticagent.executors;
 import cd.go.contrib.elasticagent.PluginRequest;
 import cd.go.contrib.elasticagent.model.ServerInfo;
 import cd.go.contrib.elasticagent.requests.ClusterProfileValidateRequest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ClusterStatusReportExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ClusterStatusReportExecutorTest.java
@@ -29,11 +29,10 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.internal.NodeOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationsImpl;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -45,7 +44,7 @@ public class ClusterStatusReportExecutorTest {
     private ClusterProfileProperties clusterProfileProperties;
     private KubernetesClient kubernetesClient;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         kubernetesClientFactory = mock(KubernetesClientFactory.class);
         request = mock(ClusterStatusReportRequest.class);
@@ -76,7 +75,7 @@ public class ClusterStatusReportExecutorTest {
 
         final GoPluginApiResponse response = new ClusterStatusReportExecutor(request, builder, kubernetesClientFactory).execute();
 
-        assertThat(response.responseCode(), is(200));
-        assertThat(response.responseBody(), is("{\"view\":\"status-report\"}"));
+        assertThat(response.responseCode()).isEqualTo(200);
+        assertThat(response.responseBody()).isEqualTo("{\"view\":\"status-report\"}");
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/executors/CreateAgentRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/CreateAgentRequestExecutorTest.java
@@ -19,11 +19,11 @@ package cd.go.contrib.elasticagent.executors;
 import cd.go.contrib.elasticagent.*;
 import cd.go.contrib.elasticagent.model.JobIdentifier;
 import cd.go.contrib.elasticagent.requests.CreateAgentRequest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 public class CreateAgentRequestExecutorTest {
@@ -54,12 +54,8 @@ public class CreateAgentRequestExecutorTest {
 
         when(agentInstances.create(any(), any(), any(), any())).thenThrow(new RuntimeException("Ouch!"));
 
-        try {
-            new CreateAgentRequestExecutor(request, agentInstances, pluginRequest).execute();
-            fail("Should have thrown an exception.");
-        } catch (Exception e) {
-            // This is expected. Ignore.
-        }
+        assertThrows(Exception.class, () -> new CreateAgentRequestExecutor(request, agentInstances, pluginRequest).execute());
+
         verify(pluginRequest).appendToConsoleLog(any(), contains("Received request to create a pod for job"));
         verify(pluginRequest).appendToConsoleLog(any(), contains("Failed to create agent pod"));
     }

--- a/src/test/java/cd/go/contrib/elasticagent/executors/GetCapabilitiesExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/GetCapabilitiesExecutorTest.java
@@ -17,11 +17,11 @@
 package cd.go.contrib.elasticagent.executors;
 
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class GetCapabilitiesExecutorTest {
 
@@ -29,7 +29,7 @@ public class GetCapabilitiesExecutorTest {
     public void shouldSupportStatusReport() throws Exception {
         final GoPluginApiResponse response = new GetCapabilitiesExecutor().execute();
 
-        assertThat(response.responseCode(), is(200));
+        assertThat(response.responseCode()).isEqualTo(200);
         String expected = "{" +
                 "  \"supports_plugin_status_report\":false," +
                 "  \"supports_cluster_status_report\":true," +

--- a/src/test/java/cd/go/contrib/elasticagent/executors/GetClusterProfileMetadataExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/GetClusterProfileMetadataExecutorTest.java
@@ -20,14 +20,14 @@ import cd.go.contrib.elasticagent.model.Field;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 public class GetClusterProfileMetadataExecutorTest {
     @Test
@@ -42,7 +42,7 @@ public class GetClusterProfileMetadataExecutorTest {
     public void assertJsonStructure() throws Exception {
         GoPluginApiResponse response = new GetClusterProfileMetadataExecutor().execute();
 
-        assertThat(response.responseCode(), is(200));
+        assertThat(response.responseCode()).isEqualTo(200);
         String expectedJSON = "[\n" +
                 "  {\n" +
                 "    \"key\": \"go_server_url\",\n" +

--- a/src/test/java/cd/go/contrib/elasticagent/executors/GetClusterProfileViewRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/GetClusterProfileViewRequestExecutorTest.java
@@ -21,26 +21,24 @@ import cd.go.contrib.elasticagent.utils.Util;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
-import org.hamcrest.Matchers;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class GetClusterProfileViewRequestExecutorTest {
     @Test
     public void shouldRenderTheTemplateInJSON() throws Exception {
         GoPluginApiResponse response = new GetClusterProfileViewRequestExecutor().execute();
-        assertThat(response.responseCode(), is(200));
+        assertThat(response.responseCode()).isEqualTo(200);
         Map<String, String> hashSet = new Gson().fromJson(response.responseBody(), new TypeToken<Map<String, String>>() {
         }.getType());
-        assertThat(hashSet, Matchers.hasEntry("template", Util.readResource("/plugin-settings.template.html")));
+        assertThat(hashSet).containsEntry("template", Util.readResource("/plugin-settings.template.html"));
     }
 
     @Test
@@ -50,15 +48,15 @@ public class GetClusterProfileViewRequestExecutorTest {
 
         for (Metadata field : GetClusterProfileMetadataExecutor.FIELDS) {
             final Elements inputFieldForKey = document.getElementsByAttributeValue("ng-model", field.getKey());
-            assertThat(inputFieldForKey, hasSize(1));
+            assertThat(inputFieldForKey).hasSize(1);
 
             final Elements spanToShowError = document.getElementsByAttributeValue("ng-show", "GOINPUTNAME[" + field.getKey() + "].$error.server");
-            assertThat(spanToShowError, hasSize(1));
-            assertThat(spanToShowError.attr("ng-show"), is("GOINPUTNAME[" + field.getKey() + "].$error.server"));
-            assertThat(spanToShowError.text(), is("{{GOINPUTNAME[" + field.getKey() + "].$error.server}}"));
+            assertThat(spanToShowError).hasSize(1);
+            assertThat(spanToShowError.attr("ng-show")).isEqualTo("GOINPUTNAME[" + field.getKey() + "].$error.server");
+            assertThat(spanToShowError.text()).isEqualTo("{{GOINPUTNAME[" + field.getKey() + "].$error.server}}");
         }
 
         final Elements inputs = document.select("textarea,input[type=text],select,input[type=checkbox]");
-        assertThat(inputs, hasSize(GetProfileMetadataExecutor.FIELDS.size() - 3)); // do not include SPECIFIED_USING_POD_CONFIGURATION, POD_SPEC_TYPE, REMOTE_FILE_TYPE key
+        assertThat(inputs).hasSize(GetProfileMetadataExecutor.FIELDS.size() - 3); // do not include SPECIFIED_USING_POD_CONFIGURATION, POD_SPEC_TYPE, REMOTE_FILE_TYPE key
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/executors/GetPluginSettingsIconExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/GetPluginSettingsIconExecutorTest.java
@@ -20,13 +20,13 @@ import cd.go.contrib.elasticagent.utils.Util;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
 import java.util.HashMap;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class GetPluginSettingsIconExecutorTest {
 
@@ -34,8 +34,8 @@ public class GetPluginSettingsIconExecutorTest {
     public void rendersIconInBase64() throws Exception {
         GoPluginApiResponse response = new GetPluginSettingsIconExecutor().execute();
         HashMap<String, String> hashMap = new Gson().fromJson(response.responseBody(), new TypeToken<HashMap<String, String>>(){}.getType());
-        assertThat(hashMap.size(), is(2));
-        assertThat(hashMap.get("content_type"), is("image/svg+xml"));
-        assertThat(Util.readResourceBytes("/kubernetes_logo.svg"), is(Base64.getDecoder().decode(hashMap.get("data"))));
+        assertThat(hashMap.size()).isEqualTo(2);
+        assertThat(hashMap.get("content_type")).isEqualTo("image/svg+xml");
+        assertThat(Util.readResourceBytes("/kubernetes_logo.svg")).isEqualTo(Base64.getDecoder().decode(hashMap.get("data")));
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/executors/GetProfileMetadataExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/GetProfileMetadataExecutorTest.java
@@ -20,14 +20,13 @@ import cd.go.contrib.elasticagent.model.Field;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetProfileMetadataExecutorTest {
     @Test
@@ -42,7 +41,7 @@ public class GetProfileMetadataExecutorTest {
     public void assertJsonStructure() throws Exception {
         GoPluginApiResponse response = new GetProfileMetadataExecutor().execute();
 
-        assertThat(response.responseCode(), is(200));
+        assertThat(response.responseCode()).isEqualTo(200);
         String expectedJSON = "[\n" +
                 "  {\n" +
                 "    \"key\": \"Image\",\n" +

--- a/src/test/java/cd/go/contrib/elasticagent/executors/GetProfileViewExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/GetProfileViewExecutorTest.java
@@ -24,21 +24,21 @@ import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class GetProfileViewExecutorTest {
     @Test
     public void shouldRenderTheTemplateInJSON() throws Exception {
         GoPluginApiResponse response = new GetProfileViewExecutor().execute();
-        assertThat(response.responseCode(), is(200));
+        assertThat(response.responseCode()).isEqualTo(200);
         Map<String, String> hashSet = new Gson().fromJson(response.responseBody(), new TypeToken<Map<String, String>>() {
         }.getType());
-        assertThat(hashSet, hasEntry("template", Util.readResource("/profile.template.html")));
+        assertThat(hashSet).containsEntry("template", Util.readResource("/profile.template.html"));
     }
 
     @Test
@@ -51,15 +51,15 @@ public class GetProfileViewExecutorTest {
                 continue;
             }
             final Elements inputFieldForKey = document.getElementsByAttributeValue("ng-model", field.getKey());
-            assertThat(inputFieldForKey, hasSize(1));
+            assertThat(inputFieldForKey).hasSize(1);
 
             final Elements spanToShowError = document.getElementsByAttributeValue("ng-class", "{'is-visible': GOINPUTNAME[" + field.getKey() + "].$error.server}");
-            assertThat(spanToShowError, hasSize(1));
-            assertThat(spanToShowError.attr("ng-show"), is("GOINPUTNAME[" + field.getKey() + "].$error.server"));
-            assertThat(spanToShowError.text(), is("{{GOINPUTNAME[" + field.getKey() + "].$error.server}}"));
+            assertThat(spanToShowError).hasSize(1);
+            assertThat(spanToShowError.attr("ng-show")).isEqualTo("GOINPUTNAME[" + field.getKey() + "].$error.server");
+            assertThat(spanToShowError.text()).isEqualTo("{{GOINPUTNAME[" + field.getKey() + "].$error.server}}");
         }
 
         final Elements inputs = document.select("textarea,input[type=text],select,input[type=checkbox]");
-        assertThat(inputs, hasSize(GetProfileMetadataExecutor.FIELDS.size() - 3)); // do not include SPECIFIED_USING_POD_CONFIGURATION, POD_SPEC_TYPE, REMOTE_FILE_TYPE key
+        assertThat(inputs).hasSize(GetProfileMetadataExecutor.FIELDS.size() - 3); // do not include SPECIFIED_USING_POD_CONFIGURATION, POD_SPEC_TYPE, REMOTE_FILE_TYPE key
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/executors/JobCompletionRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/JobCompletionRequestExecutorTest.java
@@ -20,8 +20,8 @@ import cd.go.contrib.elasticagent.*;
 import cd.go.contrib.elasticagent.model.JobIdentifier;
 import cd.go.contrib.elasticagent.requests.JobCompletionRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
@@ -30,11 +30,11 @@ import org.mockito.Mock;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class JobCompletionRequestExecutorTest {
 
@@ -46,9 +46,9 @@ public class JobCompletionRequestExecutorTest {
     @Captor
     private ArgumentCaptor<List<Agent>> agentsArgumentCaptor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test

--- a/src/test/java/cd/go/contrib/elasticagent/executors/MemoryMetadataTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/MemoryMetadataTest.java
@@ -17,14 +17,13 @@
 package cd.go.contrib.elasticagent.executors;
 
 import cd.go.contrib.elasticagent.model.MemoryMetadata;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class MemoryMetadataTest {
 
@@ -33,16 +32,16 @@ public class MemoryMetadataTest {
         assertTrue(new MemoryMetadata("Disk", false).validate("100mb").isEmpty());
 
         Map<String, String> validate = new MemoryMetadata("Disk", false).validate("xxx");
-        assertThat(validate.size(), is(2));
-        assertThat(validate, hasEntry("message", "Invalid size: xxx"));
-        assertThat(validate, hasEntry("key", "Disk"));
+        assertThat(validate.size()).isEqualTo(2);
+        assertThat(validate).containsEntry("message", "Invalid size: xxx");
+        assertThat(validate).containsEntry("key", "Disk");
     }
 
     @Test
     public void shouldValidateMemoryBytesWhenRequireField() throws Exception {
         Map<String, String> validate = new MemoryMetadata("Disk", true).validate(null);
-        assertThat(validate.size(), is(2));
-        assertThat(validate, hasEntry("message", "Disk must not be blank."));
-        assertThat(validate, hasEntry("key", "Disk"));
+        assertThat(validate.size()).isEqualTo(2);
+        assertThat(validate).containsEntry("message", "Disk must not be blank.");
+        assertThat(validate).containsEntry("key", "Disk");
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/executors/MigrateConfigurationRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/MigrateConfigurationRequestExecutorTest.java
@@ -22,17 +22,15 @@ import cd.go.contrib.elasticagent.ElasticAgentProfile;
 import cd.go.contrib.elasticagent.PluginSettings;
 import cd.go.contrib.elasticagent.requests.MigrateConfigurationRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MigrateConfigurationRequestExecutorTest {
     private PluginSettings pluginSettings;
@@ -40,7 +38,7 @@ public class MigrateConfigurationRequestExecutorTest {
     private ElasticAgentProfile elasticAgentProfile;
     private HashMap<String, String> properties;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         pluginSettings = new PluginSettings("https://127.0.0.1:8154/go", "https://my.kubernetes-cluster.com", "ca-cert");
 
@@ -68,9 +66,9 @@ public class MigrateConfigurationRequestExecutorTest {
 
         MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
 
-        assertThat(responseObject.getPluginSettings(), is(new PluginSettings()));
-        assertThat(responseObject.getClusterProfiles(), is(Collections.singletonList(clusterProfile)));
-        assertThat(responseObject.getElasticAgentProfiles(), is(Collections.singletonList(elasticAgentProfile)));
+        assertThat(responseObject.getPluginSettings()).isEqualTo(new PluginSettings());
+        assertThat(responseObject.getClusterProfiles()).isEqualTo(Collections.singletonList(clusterProfile));
+        assertThat(responseObject.getElasticAgentProfiles()).isEqualTo(Collections.singletonList(elasticAgentProfile));
     }
 
     @Test
@@ -82,9 +80,9 @@ public class MigrateConfigurationRequestExecutorTest {
 
         MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
 
-        assertThat(responseObject.getPluginSettings(), is(pluginSettings));
-        assertThat(responseObject.getClusterProfiles(), is(Collections.singletonList(clusterProfile)));
-        assertThat(responseObject.getElasticAgentProfiles(), is(Collections.singletonList(elasticAgentProfile)));
+        assertThat(responseObject.getPluginSettings()).isEqualTo(pluginSettings);
+        assertThat(responseObject.getClusterProfiles()).isEqualTo(Collections.singletonList(clusterProfile));
+        assertThat(responseObject.getElasticAgentProfiles()).isEqualTo(Collections.singletonList(elasticAgentProfile));
     }
 
     @Test
@@ -98,17 +96,17 @@ public class MigrateConfigurationRequestExecutorTest {
 
         MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
 
-        assertThat(responseObject.getPluginSettings(), is(pluginSettings));
+        assertThat(responseObject.getPluginSettings()).isEqualTo(pluginSettings);
         List<ClusterProfile> actual = responseObject.getClusterProfiles();
         ClusterProfile actualClusterProfile = actual.get(0);
 
-        assertThat(actualClusterProfile.getId(), is(not(String.format("no-op-cluster-for-%s", Constants.PLUGIN_ID))));
+        assertThat(actualClusterProfile.getId()).isNotEqualTo(String.format("no-op-cluster-for-%s", Constants.PLUGIN_ID));
         this.clusterProfile.setId(actualClusterProfile.getId());
 
-        assertThat(actual, is(Collections.singletonList(this.clusterProfile)));
-        assertThat(responseObject.getElasticAgentProfiles(), is(Collections.singletonList(elasticAgentProfile)));
+        assertThat(actual).isEqualTo(Collections.singletonList(this.clusterProfile));
+        assertThat(responseObject.getElasticAgentProfiles()).isEqualTo(Collections.singletonList(elasticAgentProfile));
 
-        assertThat(elasticAgentProfile.getClusterProfileId(), is(actualClusterProfile.getId()));
+        assertThat(elasticAgentProfile.getClusterProfileId()).isEqualTo(actualClusterProfile.getId());
     }
 
     @Test
@@ -123,17 +121,17 @@ public class MigrateConfigurationRequestExecutorTest {
 
         MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
 
-        assertThat(responseObject.getPluginSettings(), is(pluginSettings));
+        assertThat(responseObject.getPluginSettings()).isEqualTo(pluginSettings);
         List<ClusterProfile> actual = responseObject.getClusterProfiles();
         ClusterProfile actualClusterProfile = actual.get(0);
 
-        assertThat(actualClusterProfile.getId(), is(clusterProfileId));
+        assertThat(actualClusterProfile.getId()).isEqualTo(clusterProfileId);
         this.clusterProfile.setId(actualClusterProfile.getId());
 
-        assertThat(actual, is(Collections.singletonList(this.clusterProfile)));
-        assertThat(responseObject.getElasticAgentProfiles(), is(Collections.singletonList(elasticAgentProfile)));
+        assertThat(actual).isEqualTo(Collections.singletonList(this.clusterProfile));
+        assertThat(responseObject.getElasticAgentProfiles()).isEqualTo(Collections.singletonList(elasticAgentProfile));
 
-        assertThat(elasticAgentProfile.getClusterProfileId(), is(clusterProfileId));
+        assertThat(elasticAgentProfile.getClusterProfileId()).isEqualTo(clusterProfileId);
     }
 
     @Test
@@ -145,13 +143,13 @@ public class MigrateConfigurationRequestExecutorTest {
 
         MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
 
-        assertThat(responseObject.getPluginSettings(), is(pluginSettings));
+        assertThat(responseObject.getPluginSettings()).isEqualTo(pluginSettings);
         List<ClusterProfile> actual = responseObject.getClusterProfiles();
         ClusterProfile actualClusterProfile = actual.get(0);
         this.clusterProfile.setId(actualClusterProfile.getId());
 
-        assertThat(actual, is(Collections.singletonList(this.clusterProfile)));
-        assertThat(responseObject.getElasticAgentProfiles(), is(Collections.emptyList()));
+        assertThat(actual).isEqualTo(Collections.singletonList(this.clusterProfile));
+        assertThat(responseObject.getElasticAgentProfiles()).isEqualTo(Collections.emptyList());
     }
 
     @Test
@@ -176,16 +174,16 @@ public class MigrateConfigurationRequestExecutorTest {
 
         MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
 
-        assertThat(responseObject.getPluginSettings(), is(pluginSettings));
+        assertThat(responseObject.getPluginSettings()).isEqualTo(pluginSettings);
 
         this.clusterProfile.setId(responseObject.getClusterProfiles().get(0).getId());
-        assertThat(responseObject.getClusterProfiles().get(0), is(clusterProfile));
+        assertThat(responseObject.getClusterProfiles().get(0)).isEqualTo(clusterProfile);
 
         this.clusterProfile.setId(responseObject.getClusterProfiles().get(1).getId());
-        assertThat(responseObject.getClusterProfiles().get(1), is(clusterProfile));
+        assertThat(responseObject.getClusterProfiles().get(1)).isEqualTo(clusterProfile);
 
-        assertThat(responseObject.getElasticAgentProfiles().get(0).getClusterProfileId(), is(emptyCluster1.getId()));
-        assertThat(responseObject.getElasticAgentProfiles().get(1).getClusterProfileId(), is(emptyCluster2.getId()));
+        assertThat(responseObject.getElasticAgentProfiles().get(0).getClusterProfileId()).isEqualTo(emptyCluster1.getId());
+        assertThat(responseObject.getElasticAgentProfiles().get(1).getClusterProfileId()).isEqualTo(emptyCluster2.getId());
     }
 
     @Test
@@ -210,16 +208,16 @@ public class MigrateConfigurationRequestExecutorTest {
 
         MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
 
-        assertThat(responseObject.getPluginSettings(), is(pluginSettings));
+        assertThat(responseObject.getPluginSettings()).isEqualTo(pluginSettings);
 
         this.clusterProfile.setId(responseObject.getClusterProfiles().get(0).getId());
-        assertThat(responseObject.getClusterProfiles().get(0), is(clusterProfile));
+        assertThat(responseObject.getClusterProfiles().get(0)).isEqualTo(clusterProfile);
 
         //verify cluster is empty.. not migrated
-        assertThat(responseObject.getClusterProfiles().get(1), is(emptyCluster2));
+        assertThat(responseObject.getClusterProfiles().get(1)).isEqualTo(emptyCluster2);
 
-        assertThat(responseObject.getElasticAgentProfiles().get(0).getClusterProfileId(), is(emptyCluster1.getId()));
-        assertThat(responseObject.getElasticAgentProfiles().get(1).getClusterProfileId(), is(emptyCluster1.getId()));
+        assertThat(responseObject.getElasticAgentProfiles().get(0).getClusterProfileId()).isEqualTo(emptyCluster1.getId());
+        assertThat(responseObject.getElasticAgentProfiles().get(1).getClusterProfileId()).isEqualTo(emptyCluster1.getId());
     }
 
     @Test
@@ -244,10 +242,10 @@ public class MigrateConfigurationRequestExecutorTest {
 
         MigrateConfigurationRequest responseObject = MigrateConfigurationRequest.fromJSON(response.responseBody());
 
-        assertThat(responseObject.getPluginSettings(), is(pluginSettings));
+        assertThat(responseObject.getPluginSettings()).isEqualTo(pluginSettings);
 
-        assertThat(responseObject.getClusterProfiles(), is(Arrays.asList(cluster1, cluster2)));
+        assertThat(responseObject.getClusterProfiles()).isEqualTo(Arrays.asList(cluster1, cluster2));
 
-        assertThat(responseObject.getElasticAgentProfiles(), is(Arrays.asList(elasticAgentProfile1, elasticAgentProfile2)));
+        assertThat(responseObject.getElasticAgentProfiles()).isEqualTo(Arrays.asList(elasticAgentProfile1, elasticAgentProfile2));
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ProfileValidateRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ProfileValidateRequestExecutorTest.java
@@ -17,7 +17,7 @@
 package cd.go.contrib.elasticagent.executors;
 
 import cd.go.contrib.elasticagent.requests.ProfileValidateRequest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
@@ -26,8 +26,8 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import org.joda.time.DateTime;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -36,10 +36,10 @@ import java.util.*;
 
 import static cd.go.contrib.elasticagent.Constants.JOB_ID_LABEL_KEY;
 import static cd.go.contrib.elasticagent.utils.Util.getSimpleDateFormat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class ServerPingRequestExecutorTest extends BaseTest {
     @Mock
@@ -56,9 +56,9 @@ public class ServerPingRequestExecutorTest extends BaseTest {
     private PodResource<Pod, DoneablePod> podResource;
     private ObjectMeta objectMetadata;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
+        openMocks(this);
         when(factory.client(any())).thenReturn(mockedClient);
         when(mockedClient.pods()).thenReturn(mockedOperation);
         when(mockedOperation.create(any(Pod.class))).thenAnswer(new Answer<Pod>() {
@@ -128,13 +128,13 @@ public class ServerPingRequestExecutorTest extends BaseTest {
 
     @Test
     public void testShouldTerminateKubernetesPodsRunningAfterTimeout_forMultipleClusters() throws Exception {
-        String agentId1 = "agentId1-" + UUID.randomUUID().toString();
-        String agentId2 = "agentId2-" + UUID.randomUUID().toString();
-        String agentId3 = "agentId3-" + UUID.randomUUID().toString();
+        String agentId1 = "agentId1-" + UUID.randomUUID();
+        String agentId2 = "agentId2-" + UUID.randomUUID();
+        String agentId3 = "agentId3-" + UUID.randomUUID();
 
-        String agentId4 = "agentId4-" + UUID.randomUUID().toString();
-        String agentId5 = "agentId5-" + UUID.randomUUID().toString();
-        String agentId6 = "agentId6-" + UUID.randomUUID().toString();
+        String agentId4 = "agentId4-" + UUID.randomUUID();
+        String agentId5 = "agentId5-" + UUID.randomUUID();
+        String agentId6 = "agentId6-" + UUID.randomUUID();
 
         ClusterProfileProperties clusterProfilePropertiesForCluster1 = new ClusterProfileProperties("https://localhost:8154/go", null, null);
         ClusterProfileProperties clusterProfilePropertiesForCluster2 = new ClusterProfileProperties("https://localhost:8254/go", null, null);
@@ -201,8 +201,8 @@ public class ServerPingRequestExecutorTest extends BaseTest {
 
     @Test
     public void testShouldTerminateUnregisteredInstances_forSingleCluster() throws Exception {
-        String unregisteredAgentId1 = "unregisteredAgentId1-" + UUID.randomUUID().toString();
-        String unregisteredAgentId2 = "unregisteredAgentId2-" + UUID.randomUUID().toString();
+        String unregisteredAgentId1 = "unregisteredAgentId1-" + UUID.randomUUID();
+        String unregisteredAgentId2 = "unregisteredAgentId2-" + UUID.randomUUID();
 
         long time = Calendar.getInstance().getTimeInMillis();
         Pod mockedPod = mock(Pod.class);

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ShouldAssignWorkRequestExecutorTest.java
@@ -27,8 +27,8 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -38,12 +38,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
     @Mock
@@ -61,9 +60,9 @@ public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
     private MixedOperation<Pod, PodList, DoneablePod, PodResource<Pod, DoneablePod>> mockedOperation;
     private String environment = "QA";
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-        initMocks(this);
+        openMocks(this);
         when(factory.client(any())).thenReturn(mockedClient);
         when(mockedClient.pods()).thenReturn(mockedOperation);
 
@@ -90,8 +89,8 @@ public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
         JobIdentifier jobIdentifier = new JobIdentifier("test-pipeline", 1L, "Test Pipeline", "test-stage", "1", "test-job", 100L);
         ShouldAssignWorkRequest request = new ShouldAssignWorkRequest(new Agent(instance.name(), null, null, null), environment, properties, jobIdentifier);
         GoPluginApiResponse response = new ShouldAssignWorkRequestExecutor(request, agentInstances).execute();
-        assertThat(response.responseCode(), is(200));
-        assertThat(response.responseBody(), is("true"));
+        assertThat(response.responseCode()).isEqualTo(200);
+        assertThat(response.responseBody()).isEqualTo("true");
     }
 
     @Test
@@ -100,7 +99,7 @@ public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
         JobIdentifier jobIdentifier = new JobIdentifier("test-pipeline", 1L, "Test Pipeline", "test-stage", "1", "test-job", mismatchingJobId);
         ShouldAssignWorkRequest request = new ShouldAssignWorkRequest(new Agent(instance.name(), null, null, null), "FooEnv", properties, jobIdentifier);
         GoPluginApiResponse response = new ShouldAssignWorkRequestExecutor(request, agentInstances).execute();
-        assertThat(response.responseCode(), is(200));
-        assertThat(response.responseBody(), is("false"));
+        assertThat(response.responseCode()).isEqualTo(200);
+        assertThat(response.responseBody()).isEqualTo("false");
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/model/JobIdentifierTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/model/JobIdentifierTest.java
@@ -1,10 +1,10 @@
 package cd.go.contrib.elasticagent.model;
 
-import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JobIdentifierTest {
     @Test
@@ -13,42 +13,42 @@ public class JobIdentifierTest {
 
         final JobIdentifier deserializedJobIdentifier = JobIdentifier.fromJson(jobIdentifier.toJson());
 
-        assertTrue(jobIdentifier.equals(deserializedJobIdentifier));
+        assertEquals(jobIdentifier, deserializedJobIdentifier);
     }
 
     @Test
     public void shouldCreateRepresentationFromJobIdentifier() {
         final JobIdentifier jobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 876578L);
 
-        assertThat(jobIdentifier.getRepresentation(), is("up42/98765/stage_1/30000/job_1"));
+        assertThat(jobIdentifier.getRepresentation()).isEqualTo("up42/98765/stage_1/30000/job_1");
     }
 
     @Test
     public void shouldCreatePipelineHistoryPageLink() {
         final JobIdentifier jobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 876578L);
 
-        assertThat(jobIdentifier.getPipelineHistoryPageLink(), is("/go/tab/pipeline/history/up42"));
+        assertThat(jobIdentifier.getPipelineHistoryPageLink()).isEqualTo("/go/tab/pipeline/history/up42");
     }
 
     @Test
     public void shouldCreateVSMPageLink() {
         final JobIdentifier jobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 876578L);
 
-        assertThat(jobIdentifier.getVsmPageLink(), is("/go/pipelines/value_stream_map/up42/98765"));
+        assertThat(jobIdentifier.getVsmPageLink()).isEqualTo("/go/pipelines/value_stream_map/up42/98765");
     }
 
     @Test
     public void shouldCreateStageDetailsPageLink() {
         final JobIdentifier jobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 876578L);
 
-        assertThat(jobIdentifier.getStageDetailsPageLink(), is("/go/pipelines/up42/98765/stage_1/30000"));
+        assertThat(jobIdentifier.getStageDetailsPageLink()).isEqualTo("/go/pipelines/up42/98765/stage_1/30000");
     }
 
     @Test
     public void shouldCreateJobDetailsPageLink() {
         final JobIdentifier jobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 876578L);
 
-        assertThat(jobIdentifier.getJobDetailsPageLink(), is("/go/tab/build/detail/up42/98765/stage_1/30000/job_1"));
+        assertThat(jobIdentifier.getJobDetailsPageLink()).isEqualTo("/go/tab/build/detail/up42/98765/stage_1/30000/job_1");
     }
 
 }

--- a/src/test/java/cd/go/contrib/elasticagent/model/KubernetesClusterTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/model/KubernetesClusterTest.java
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.internal.NodeOperationsImpl;
 import io.fabric8.kubernetes.client.dsl.internal.PodOperationsImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/cd/go/contrib/elasticagent/model/reports/agent/StatusReportGenerationErrorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/model/reports/agent/StatusReportGenerationErrorTest.java
@@ -24,12 +24,11 @@ import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import freemarker.template.TemplateException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -42,13 +41,13 @@ public class StatusReportGenerationErrorTest {
 
         final GoPluginApiResponse response = StatusReportGenerationErrorHandler.handle(PluginStatusReportViewBuilder.instance(), exception);
 
-        assertThat(response.responseCode(), is(200));
+        assertThat(response.responseCode()).isEqualTo(200);
 
-        final String view = new JsonParser().parse(response.responseBody()).getAsJsonObject().get("view").getAsString();
+        final String view = JsonParser.parseString(response.responseBody()).getAsJsonObject().get("view").getAsString();
         final Document document = Jsoup.parse(view);
 
-        assertThat(document.select(".outer-container .container .error-container blockquote header").text(), is("Pod is not running."));
-        assertThat(document.select(".outer-container .container .error-container blockquote p").text(), is("Can not find a running pod for the provided elastic agent id 'foo'."));
+        assertThat(document.select(".outer-container .container .error-container blockquote header").text()).isEqualTo("Pod is not running.");
+        assertThat(document.select(".outer-container .container .error-container blockquote p").text()).isEqualTo("Can not find a running pod for the provided elastic agent id 'foo'.");
     }
 
     @Test
@@ -61,7 +60,7 @@ public class StatusReportGenerationErrorTest {
 
         final GoPluginApiResponse response = StatusReportGenerationErrorHandler.handle(viewBuilder, exception);
 
-        assertThat(response.responseCode(), is(500));
-        assertThat(response.responseBody(), is("Failed to generate error report: cd.go.contrib.elasticagent.reports.StatusReportGenerationException: Pod is not running."));
+        assertThat(response.responseCode()).isEqualTo(500);
+        assertThat(response.responseBody()).isEqualTo("Failed to generate error report: cd.go.contrib.elasticagent.reports.StatusReportGenerationException: Pod is not running.");
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/requests/AgentStatusReportRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/requests/AgentStatusReportRequestTest.java
@@ -19,12 +19,12 @@ package cd.go.contrib.elasticagent.requests;
 import cd.go.contrib.elasticagent.ClusterProfileProperties;
 import cd.go.contrib.elasticagent.JobIdentifierMother;
 import com.google.gson.JsonObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class AgentStatusReportRequestTest {
     @Test
@@ -37,7 +37,7 @@ public class AgentStatusReportRequestTest {
         AgentStatusReportRequest agentStatusReportRequest = AgentStatusReportRequest.fromJSON(jsonObject.toString());
 
         AgentStatusReportRequest expected = new AgentStatusReportRequest("some-id", JobIdentifierMother.get(), null);
-        assertThat(agentStatusReportRequest, is(expected));
+        assertThat(agentStatusReportRequest).isEqualTo(expected);
     }
 
     @Test
@@ -57,7 +57,7 @@ public class AgentStatusReportRequestTest {
         ClusterProfileProperties expectedClusterProfileProperties = ClusterProfileProperties.fromConfiguration(clusterProfileConfigurations);
 
         AgentStatusReportRequest expected = new AgentStatusReportRequest("some-id", JobIdentifierMother.get(), expectedClusterProfileProperties);
-        assertThat(agentStatusReportRequest, is(expected));
+        assertThat(agentStatusReportRequest).isEqualTo(expected);
     }
 
 }

--- a/src/test/java/cd/go/contrib/elasticagent/requests/ClusterStatusReportRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/requests/ClusterStatusReportRequestTest.java
@@ -17,12 +17,12 @@
 package cd.go.contrib.elasticagent.requests;
 
 import com.google.gson.JsonObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class ClusterStatusReportRequestTest {
     @Test
@@ -35,6 +35,6 @@ public class ClusterStatusReportRequestTest {
         ClusterStatusReportRequest clusterStatusReportRequest = ClusterStatusReportRequest.fromJSON(jsonObject.toString());
 
         ClusterStatusReportRequest expected = new ClusterStatusReportRequest(Collections.singletonMap("go_server_url", "https://go-server/go"));
-        assertThat(clusterStatusReportRequest, is(expected));
+        assertThat(clusterStatusReportRequest).isEqualTo(expected);
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/requests/CreateAgentRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/requests/CreateAgentRequestTest.java
@@ -18,15 +18,11 @@ package cd.go.contrib.elasticagent.requests;
 
 import cd.go.contrib.elasticagent.ClusterProfileProperties;
 import cd.go.contrib.elasticagent.model.JobIdentifier;
-import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
-import java.util.Map;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CreateAgentRequestTest {
 
@@ -54,21 +50,21 @@ public class CreateAgentRequestTest {
                 "}";
 
         CreateAgentRequest request = CreateAgentRequest.fromJSON(json);
-        assertThat(request.autoRegisterKey(), equalTo("secret-key"));
-        assertThat(request.environment(), equalTo("prod"));
+        assertThat(request.autoRegisterKey()).isEqualTo("secret-key");
+        assertThat(request.environment()).isEqualTo("prod");
         HashMap<String, String> expectedElasticAgentProperties = new HashMap<>();
         expectedElasticAgentProperties.put("key1", "value1");
         expectedElasticAgentProperties.put("key2", "value2");
-        assertThat(request.properties(), Matchers.<Map<String, String>>equalTo(expectedElasticAgentProperties));
+        assertThat(request.properties()).isEqualTo(expectedElasticAgentProperties);
 
         HashMap<String, String> clusterProfileConfigurations = new HashMap<>();
         clusterProfileConfigurations.put("go_server_url", "go-server-url");
         ClusterProfileProperties expectedClusterProfileProperties = ClusterProfileProperties.fromConfiguration(clusterProfileConfigurations);
-        assertThat(request.clusterProfileProperties(), is(expectedClusterProfileProperties));
+        assertThat(request.clusterProfileProperties()).isEqualTo(expectedClusterProfileProperties);
 
         JobIdentifier expectedJobIdentifier = new JobIdentifier("test-pipeline", 1L, "Test Pipeline", "test-stage", "1", "test-job", 100L);
         JobIdentifier actualJobIdentifier = request.jobIdentifier();
 
-        assertThat(actualJobIdentifier, is(expectedJobIdentifier));
+        assertThat(actualJobIdentifier).isEqualTo(expectedJobIdentifier);
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/requests/JobCompletionRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/requests/JobCompletionRequestTest.java
@@ -18,14 +18,11 @@ package cd.go.contrib.elasticagent.requests;
 
 import cd.go.contrib.elasticagent.ClusterProfileProperties;
 import cd.go.contrib.elasticagent.model.JobIdentifier;
-import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
-import java.util.Map;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JobCompletionRequestTest {
     @Test
@@ -55,19 +52,19 @@ public class JobCompletionRequestTest {
         HashMap<String, String> expectedElasticAgentProperties = new HashMap<>();
         expectedElasticAgentProperties.put("key1", "value1");
         expectedElasticAgentProperties.put("key2", "value2");
-        assertThat(request.properties(), Matchers.<Map<String, String>>equalTo(expectedElasticAgentProperties));
+        assertThat(request.properties()).isEqualTo(expectedElasticAgentProperties);
 
         HashMap<String, String> clusterProfileConfigurations = new HashMap<>();
         clusterProfileConfigurations.put("go_server_url", "go-server-url");
         ClusterProfileProperties expectedClusterProfileProperties = ClusterProfileProperties.fromConfiguration(clusterProfileConfigurations);
-        assertThat(request.clusterProfileProperties(), is(expectedClusterProfileProperties));
+        assertThat(request.clusterProfileProperties()).isEqualTo(expectedClusterProfileProperties);
 
         JobIdentifier expectedJobIdentifier = new JobIdentifier("test-pipeline", 1L, "Test Pipeline", "test-stage", "1", "test-job", 100L);
         JobIdentifier actualJobIdentifier = request.jobIdentifier();
 
-        assertThat(actualJobIdentifier, is(expectedJobIdentifier));
+        assertThat(actualJobIdentifier).isEqualTo(expectedJobIdentifier);
 
-        assertThat(request.getElasticAgentId(), is("ea1"));
+        assertThat(request.getElasticAgentId()).isEqualTo("ea1");
     }
 
 }

--- a/src/test/java/cd/go/contrib/elasticagent/requests/MigrateConfigurationRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/requests/MigrateConfigurationRequestTest.java
@@ -20,14 +20,13 @@ import cd.go.contrib.elasticagent.ClusterProfile;
 import cd.go.contrib.elasticagent.ElasticAgentProfile;
 import cd.go.contrib.elasticagent.PluginSettings;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Arrays;
 import java.util.HashMap;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MigrateConfigurationRequestTest {
 
@@ -81,9 +80,9 @@ public class MigrateConfigurationRequestTest {
         properties.put("some_key2", "some_value2");
         elasticAgentProfile.setProperties(properties);
 
-        assertThat(pluginSettings, is(request.getPluginSettings()));
-        assertThat(Arrays.asList(clusterProfile), is(request.getClusterProfiles()));
-        assertThat(Arrays.asList(elasticAgentProfile), is(request.getElasticAgentProfiles()));
+        assertThat(pluginSettings).isEqualTo(request.getPluginSettings());
+        assertThat(Arrays.asList(clusterProfile)).isEqualTo(request.getClusterProfiles());
+        assertThat(Arrays.asList(elasticAgentProfile)).isEqualTo(request.getElasticAgentProfiles());
     }
 
     @Test
@@ -96,9 +95,9 @@ public class MigrateConfigurationRequestTest {
 
         MigrateConfigurationRequest request = MigrateConfigurationRequest.fromJSON(requestBody);
 
-        assertThat(new PluginSettings(), is(request.getPluginSettings()));
-        assertThat(Arrays.asList(), is(request.getClusterProfiles()));
-        assertThat(Arrays.asList(), is(request.getElasticAgentProfiles()));
+        assertThat(new PluginSettings()).isEqualTo(request.getPluginSettings());
+        assertThat(Arrays.asList()).isEqualTo(request.getClusterProfiles());
+        assertThat(Arrays.asList()).isEqualTo(request.getElasticAgentProfiles());
     }
 
     @Test

--- a/src/test/java/cd/go/contrib/elasticagent/requests/ServerPingRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/requests/ServerPingRequestTest.java
@@ -18,13 +18,13 @@ package cd.go.contrib.elasticagent.requests;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class ServerPingRequestTest {
     @Test
@@ -44,6 +44,6 @@ public class ServerPingRequestTest {
         clusterProfileConfigurations.put("go_server_url", "https://go-server/go");
         ServerPingRequest expected = new ServerPingRequest(Arrays.asList(clusterProfileConfigurations));
 
-        assertThat(serverPingRequest, is(expected));
+        assertThat(serverPingRequest).isEqualTo(expected);
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/requests/ShouldAssignWorkRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/requests/ShouldAssignWorkRequestTest.java
@@ -19,15 +19,11 @@ package cd.go.contrib.elasticagent.requests;
 import cd.go.contrib.elasticagent.Agent;
 import cd.go.contrib.elasticagent.ClusterProfileProperties;
 import cd.go.contrib.elasticagent.model.JobIdentifier;
-import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
-import java.util.Map;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ShouldAssignWorkRequestTest {
 
@@ -60,21 +56,21 @@ public class ShouldAssignWorkRequestTest {
                 "}";
 
         ShouldAssignWorkRequest request = ShouldAssignWorkRequest.fromJSON(json);
-        assertThat(request.environment(), equalTo("prod"));
-        assertThat(request.agent(), equalTo(new Agent("42", Agent.AgentState.Idle, Agent.BuildState.Idle, Agent.ConfigState.Enabled)));
+        assertThat(request.environment()).isEqualTo("prod");
+        assertThat(request.agent()).isEqualTo(new Agent("42", Agent.AgentState.Idle, Agent.BuildState.Idle, Agent.ConfigState.Enabled));
         HashMap<String, String> expectedElasticAgentProperties = new HashMap<>();
         expectedElasticAgentProperties.put("key1", "value1");
         expectedElasticAgentProperties.put("key2", "value2");
-        assertThat(request.properties(), Matchers.<Map<String, String>>equalTo(expectedElasticAgentProperties));
+        assertThat(request.properties()).isEqualTo(expectedElasticAgentProperties);
 
         HashMap<String, String> clusterProfileConfigurations = new HashMap<>();
         clusterProfileConfigurations.put("go_server_url", "go-server-url");
         ClusterProfileProperties expectedClusterProfileProperties = ClusterProfileProperties.fromConfiguration(clusterProfileConfigurations);
-        assertThat(request.clusterProfileProperties(), is(expectedClusterProfileProperties));
+        assertThat(request.clusterProfileProperties()).isEqualTo(expectedClusterProfileProperties);
 
         JobIdentifier expectedJobIdentifier = new JobIdentifier("test-pipeline", 1L, "Test Pipeline", "test-stage", "1", "test-job", 100L);
         JobIdentifier actualJobIdentifier = request.jobIdentifier();
 
-        assertThat(actualJobIdentifier, is(expectedJobIdentifier));
+        assertThat(actualJobIdentifier).isEqualTo(expectedJobIdentifier);
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagent/utils/SizeTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/utils/SizeTest.java
@@ -16,9 +16,11 @@
 
 package cd.go.contrib.elasticagent.utils;
 
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SizeTest {
 
@@ -29,24 +31,24 @@ public class SizeTest {
         assertEquals(parse.getQuantity(), 24000, 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionIfTheGivenSizeHasDifferentSuffix() {
-        Size parse = Size.parse("24000kig");
+        assertThrows(IllegalArgumentException.class, () -> Size.parse("24000kig"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionIfTheGivenSizeHasNoUint() {
-        Size parse = Size.parse("24000");
+        assertThrows(IllegalArgumentException.class, () -> Size.parse("24000"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionIfTheGivenSizeIsNull() {
-        Size.parse(null);
+        assertThrows(IllegalArgumentException.class, () -> Size.parse(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionIfTheGivenSizeIsBlank() {
-        Size.parse("");
+        assertThrows(IllegalArgumentException.class, () -> Size.parse(""));
     }
 
     @Test


### PR DESCRIPTION
As described, migrate tests only to JUnit5 and AssertJ (consistent with gocd server)