### PR TITLE
Replace guava with java 8 standard lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ ext {
 dependencies {
     compileOnly project.deps.gocdPluginApi
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
-    implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
     implementation group: 'joda-time', name: 'joda-time', version: '2.12.2'

--- a/src/main/java/cd/go/contrib/elasticagent/Agents.java
+++ b/src/main/java/cd/go/contrib/elasticagent/Agents.java
@@ -17,10 +17,9 @@
 package cd.go.contrib.elasticagent;
 
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
-
 import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Represents a map of {@link Agent#elasticAgentId()} to the {@link Agent} for easy lookups
@@ -57,11 +56,11 @@ public class Agents {
     }
 
     public Collection<Agent> findInstancesToDisable() {
-        return FluentIterable.from(agents.values()).filter(AGENT_IDLE_PREDICATE).toList();
+        return agents.values().stream().filter(AGENT_IDLE_PREDICATE).collect(Collectors.toList());
     }
 
     public Collection<Agent> findInstancesToTerminate() {
-        return FluentIterable.from(agents.values()).filter(AGENT_DISABLED_PREDICATE).toList();
+        return agents.values().stream().filter(AGENT_DISABLED_PREDICATE).collect(Collectors.toList());
     }
 
     public Set<String> agentIds() {

--- a/src/main/java/cd/go/contrib/elasticagent/utils/Size.java
+++ b/src/main/java/cd/go/contrib/elasticagent/utils/Size.java
@@ -16,52 +16,57 @@
 
 package cd.go.contrib.elasticagent.utils;
 
-import com.google.common.collect.ImmutableSortedMap;
 import io.fabric8.kubernetes.api.model.Quantity;
 import org.apache.commons.lang3.StringUtils;
 
 import java.text.DecimalFormat;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class Size implements Comparable<Size> {
     private static final Pattern SIZE_PATTERN = Pattern.compile("(\\d+)\\s*(\\S+)");
 
-    private static final Map<String, SizeUnit> SUFFIXES = ImmutableSortedMap.<String, SizeUnit>orderedBy(String.CASE_INSENSITIVE_ORDER)
-            .put("B", SizeUnit.BYTES)
-            .put("byte", SizeUnit.BYTES)
-            .put("bytes", SizeUnit.BYTES)
-            .put("K", SizeUnit.KILOBYTES)
-            .put("KB", SizeUnit.KILOBYTES)
-            .put("Ki", SizeUnit.KILOBYTES)
-            .put("KiB", SizeUnit.KILOBYTES)
-            .put("kilobyte", SizeUnit.KILOBYTES)
-            .put("kilobytes", SizeUnit.KILOBYTES)
-            .put("M", SizeUnit.MEGABYTES)
-            .put("Mi", SizeUnit.MEGABYTES)
-            .put("MB", SizeUnit.MEGABYTES)
-            .put("MiB", SizeUnit.MEGABYTES)
-            .put("megabyte", SizeUnit.MEGABYTES)
-            .put("megabytes", SizeUnit.MEGABYTES)
-            .put("G", SizeUnit.GIGABYTES)
-            .put("Gi", SizeUnit.GIGABYTES)
-            .put("GB", SizeUnit.GIGABYTES)
-            .put("GiB", SizeUnit.GIGABYTES)
-            .put("gigabyte", SizeUnit.GIGABYTES)
-            .put("gigabytes", SizeUnit.GIGABYTES)
-            .put("T", SizeUnit.TERABYTES)
-            .put("TB", SizeUnit.TERABYTES)
-            .put("Ti", SizeUnit.TERABYTES)
-            .put("TiB", SizeUnit.TERABYTES)
-            .put("terabyte", SizeUnit.TERABYTES)
-            .put("terabytes", SizeUnit.TERABYTES)
-            .build();
+    private static final Map<String, SizeUnit> SUFFIXES;
+
+    static {
+        Map<String, SizeUnit> tmpSuffixes = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        tmpSuffixes.put("B", SizeUnit.BYTES);
+        tmpSuffixes.put("byte", SizeUnit.BYTES);
+        tmpSuffixes.put("bytes", SizeUnit.BYTES);
+        tmpSuffixes.put("K", SizeUnit.KILOBYTES);
+        tmpSuffixes.put("KB", SizeUnit.KILOBYTES);
+        tmpSuffixes.put("Ki", SizeUnit.KILOBYTES);
+        tmpSuffixes.put("KiB", SizeUnit.KILOBYTES);
+        tmpSuffixes.put("kilobyte", SizeUnit.KILOBYTES);
+        tmpSuffixes.put("kilobytes", SizeUnit.KILOBYTES);
+        tmpSuffixes.put("M", SizeUnit.MEGABYTES);
+        tmpSuffixes.put("Mi", SizeUnit.MEGABYTES);
+        tmpSuffixes.put("MB", SizeUnit.MEGABYTES);
+        tmpSuffixes.put("MiB", SizeUnit.MEGABYTES);
+        tmpSuffixes.put("megabyte", SizeUnit.MEGABYTES);
+        tmpSuffixes.put("megabytes", SizeUnit.MEGABYTES);
+        tmpSuffixes.put("G", SizeUnit.GIGABYTES);
+        tmpSuffixes.put("Gi", SizeUnit.GIGABYTES);
+        tmpSuffixes.put("GB", SizeUnit.GIGABYTES);
+        tmpSuffixes.put("GiB", SizeUnit.GIGABYTES);
+        tmpSuffixes.put("gigabyte", SizeUnit.GIGABYTES);
+        tmpSuffixes.put("gigabytes", SizeUnit.GIGABYTES);
+        tmpSuffixes.put("T", SizeUnit.TERABYTES);
+        tmpSuffixes.put("TB", SizeUnit.TERABYTES);
+        tmpSuffixes.put("Ti", SizeUnit.TERABYTES);
+        tmpSuffixes.put("TiB", SizeUnit.TERABYTES);
+        tmpSuffixes.put("terabyte", SizeUnit.TERABYTES);
+        tmpSuffixes.put("terabytes", SizeUnit.TERABYTES);
+        SUFFIXES = Collections.unmodifiableMap(tmpSuffixes);
+    }
+
     private final double count;
     private final SizeUnit unit;
 
@@ -95,7 +100,9 @@ public class Size implements Comparable<Size> {
             throw new IllegalArgumentException();
         }
         final Matcher matcher = SIZE_PATTERN.matcher(size);
-        checkArgument(matcher.matches(), "Invalid size: " + size);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid size: " + size);
+        }
 
         final double count = Double.parseDouble(matcher.group(1));
         final SizeUnit unit = SUFFIXES.get(matcher.group(2));


### PR DESCRIPTION
This is a potential simplification to replace usages of Guava with equivalents in the Java standard library (since Java 8), and drop the dependency on Guava.

I ran the unit tests locally with `./gradlew test` ✅ 