### PR TITLE
Replace joda-time with java.time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 
 apply plugin: 'java'
-apply from: "https://raw.githubusercontent.com/gocd/gocd-plugin-gradle-task-helpers/master/helper.gradle?_=${(int) (new Date().toInstant().epochSecond / 60)}"
+apply from: "https://raw.githubusercontent.com/gocd/gocd-plugin-gradle-task-helpers/master/helper.gradle?_=${(int) (Instant.now().epochSecond / 60)}"
 
 gocdPlugin {
   id = 'cd.go.contrib.elasticagent.kubernetes'
@@ -65,7 +65,6 @@ dependencies {
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
-    implementation group: 'joda-time', name: 'joda-time', version: '2.12.2'
     implementation group: 'io.fabric8', name: 'kubernetes-client', version: '5.12.4'
     implementation group: 'com.github.spullara.mustache.java', name: 'compiler', version: '0.9.10'
     implementation group: 'org.freemarker', name: 'freemarker', version: '2.3.32'

--- a/src/main/java/cd/go/contrib/elasticagent/Clock.java
+++ b/src/main/java/cd/go/contrib/elasticagent/Clock.java
@@ -16,48 +16,32 @@
 
 package cd.go.contrib.elasticagent;
 
-import org.joda.time.DateTime;
-import org.joda.time.Period;
+import java.time.Instant;
 
 public interface Clock {
-    Clock DEFAULT = DateTime::new;
+    Clock DEFAULT = Instant::now;
 
-    DateTime now();
+    Instant now();
 
     class TestClock implements Clock {
 
-        DateTime time = null;
+        Instant time = null;
 
-        public TestClock(DateTime time) {
+        public TestClock(Instant time) {
             this.time = time;
         }
 
         public TestClock() {
-            this(new DateTime());
+            this(Instant.now());
         }
 
         @Override
-        public DateTime now() {
+        public Instant now() {
             return time;
         }
 
-        public TestClock reset() {
-            time = new DateTime();
-            return this;
-        }
-
-        public TestClock set(DateTime time) {
+        public TestClock set(Instant time) {
             this.time = time;
-            return this;
-        }
-
-        public TestClock rewind(Period period) {
-            this.time = this.time.minus(period);
-            return this;
-        }
-
-        public TestClock forward(Period period) {
-            this.time = this.time.plus(period);
             return this;
         }
     }

--- a/src/main/java/cd/go/contrib/elasticagent/Constants.java
+++ b/src/main/java/cd/go/contrib/elasticagent/Constants.java
@@ -19,6 +19,7 @@ package cd.go.contrib.elasticagent;
 import cd.go.contrib.elasticagent.utils.Util;
 import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 
 public interface Constants {
@@ -53,6 +54,7 @@ public interface Constants {
     String KUBERNETES_POD_KIND_LABEL_KEY = "kind";
     String KUBERNETES_POD_KIND_LABEL_VALUE = "kubernetes-elastic-agent";
     String KUBERNETES_POD_NAME_PREFIX = "k8s-ea";
+    DateTimeFormatter KUBERNETES_POD_CREATION_TIME_FORMAT = DateTimeFormatter.ISO_INSTANT;
 
     String POD_POSTFIX = "POD_POSTFIX";
     String CONTAINER_POSTFIX = "CONTAINER_POSTFIX";

--- a/src/main/java/cd/go/contrib/elasticagent/Constants.java
+++ b/src/main/java/cd/go/contrib/elasticagent/Constants.java
@@ -53,7 +53,6 @@ public interface Constants {
     String KUBERNETES_POD_KIND_LABEL_KEY = "kind";
     String KUBERNETES_POD_KIND_LABEL_VALUE = "kubernetes-elastic-agent";
     String KUBERNETES_POD_NAME_PREFIX = "k8s-ea";
-    String KUBERNETES_POD_CREATION_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
     String POD_POSTFIX = "POD_POSTFIX";
     String CONTAINER_POSTFIX = "CONTAINER_POSTFIX";

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesAgentInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesAgentInstances.java
@@ -209,7 +209,7 @@ public class KubernetesAgentInstances implements AgentInstances<KubernetesInstan
                 continue;
             }
 
-            Instant createdAt = Instant.parse(pod.getMetadata().getCreationTimestamp());
+            Instant createdAt = Constants.KUBERNETES_POD_CREATION_TIME_FORMAT.parse(pod.getMetadata().getCreationTimestamp(), Instant::from);
 
             if (clock.now().isAfter(createdAt.plus(period))) {
                 unregisteredInstances.register(kubernetesInstanceFactory.fromKubernetesPod(pod));

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesAgentInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesAgentInstances.java
@@ -22,18 +22,16 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.commons.lang3.StringUtils;
-import org.joda.time.DateTime;
-import org.joda.time.Period;
 
 import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 
 import static cd.go.contrib.elasticagent.KubernetesPlugin.LOG;
-import static cd.go.contrib.elasticagent.utils.Util.getSimpleDateFormat;
 import static java.text.MessageFormat.format;
 
 public class KubernetesAgentInstances implements AgentInstances<KubernetesInstance> {
@@ -196,7 +194,7 @@ public class KubernetesAgentInstances implements AgentInstances<KubernetesInstan
     }
 
     private KubernetesAgentInstances unregisteredAfterTimeout(PluginSettings settings, Agents knownAgents) throws Exception {
-        Period period = settings.getAutoRegisterPeriod();
+        Duration period = settings.getAutoRegisterPeriod();
         KubernetesAgentInstances unregisteredInstances = new KubernetesAgentInstances();
         KubernetesClient client = factory.client(settings);
 
@@ -211,10 +209,9 @@ public class KubernetesAgentInstances implements AgentInstances<KubernetesInstan
                 continue;
             }
 
-            Date createdAt = getSimpleDateFormat().parse(pod.getMetadata().getCreationTimestamp());
-            DateTime dateTimeCreated = new DateTime(createdAt);
+            Instant createdAt = Instant.parse(pod.getMetadata().getCreationTimestamp());
 
-            if (clock.now().isAfter(dateTimeCreated.plus(period))) {
+            if (clock.now().isAfter(createdAt.plus(period))) {
                 unregisteredInstances.register(kubernetesInstanceFactory.fromKubernetesPod(pod));
             }
         }

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesClientFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesClientFactory.java
@@ -58,14 +58,14 @@ public class KubernetesClientFactory {
         LOG.debug(format("Creating a new client because {0}.", (client == null) ? "client is null" : "cluster profile configurations has changed"));
         this.clusterProfileConfigurations = clusterProfileConfigurations;
         this.client = createClientFor(clusterProfileConfigurations);
-        this.clientCreatedTime = this.clock.now().getMillis();
+        this.clientCreatedTime = this.clock.now().toEpochMilli();
         LOG.debug("New client is created.");
 
         return this.client;
     }
 
     private void clearOutClientOnTimer() {
-        long currentTime = this.clock.now().getMillis();
+        long currentTime = this.clock.now().toEpochMilli();
         long differenceInMinutes = TimeUnit.MILLISECONDS.toMinutes(currentTime - this.clientCreatedTime);
         if (differenceInMinutes > getKubernetesClientRecycleInterval()) {
             LOG.info("Recycling kubernetes client on timer...");

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstance.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstance.java
@@ -17,21 +17,20 @@
 package cd.go.contrib.elasticagent;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
+import java.time.Instant;
 import java.util.Map;
 
 public class KubernetesInstance {
-    private final DateTime createdAt;
+    private final Instant createdAt;
     private final String environment;
     private final String name;
     private final Map<String, String> properties;
     private final Long jobId;
     private final PodState state;
 
-    public KubernetesInstance(DateTime createdAt, String environment, String name, Map<String, String> properties, Long jobId, PodState state) {
-        this.createdAt = createdAt.withZone(DateTimeZone.UTC);
+    public KubernetesInstance(Instant createdAt, String environment, String name, Map<String, String> properties, Long jobId, PodState state) {
+        this.createdAt = createdAt;
         this.environment = environment;
         this.name = name;
         this.properties = properties;
@@ -47,7 +46,7 @@ public class KubernetesInstance {
         return name;
     }
 
-    public DateTime createdAt() {
+    public Instant createdAt() {
         return createdAt;
     }
 

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
@@ -41,7 +41,6 @@ import java.util.*;
 import static cd.go.contrib.elasticagent.Constants.*;
 import static cd.go.contrib.elasticagent.KubernetesPlugin.LOG;
 import static cd.go.contrib.elasticagent.executors.GetProfileMetadataExecutor.*;
-import static cd.go.contrib.elasticagent.utils.Util.getSimpleDateFormat;
 import static java.lang.String.valueOf;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.text.MessageFormat.format;
@@ -104,7 +103,7 @@ public class KubernetesInstanceFactory {
     }
 
     private void setGoCDMetadata(CreateAgentRequest request, PluginSettings settings, PluginRequest pluginRequest, Pod elasticAgentPod) {
-        elasticAgentPod.getMetadata().setCreationTimestamp(getSimpleDateFormat().format(Instant.now()));
+        elasticAgentPod.getMetadata().setCreationTimestamp(Instant.now().toString());
 
         setContainerEnvVariables(elasticAgentPod, request, settings, pluginRequest);
         setAnnotations(elasticAgentPod, request);

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
@@ -28,15 +28,14 @@ import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URL;
-import java.text.ParseException;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 
 import static cd.go.contrib.elasticagent.Constants.*;
@@ -105,7 +104,7 @@ public class KubernetesInstanceFactory {
     }
 
     private void setGoCDMetadata(CreateAgentRequest request, PluginSettings settings, PluginRequest pluginRequest, Pod elasticAgentPod) {
-        elasticAgentPod.getMetadata().setCreationTimestamp(getSimpleDateFormat().format(new Date()));
+        elasticAgentPod.getMetadata().setCreationTimestamp(getSimpleDateFormat().format(Instant.now()));
 
         setContainerEnvVariables(elasticAgentPod, request, settings, pluginRequest);
         setAnnotations(elasticAgentPod, request);
@@ -158,14 +157,14 @@ public class KubernetesInstanceFactory {
         KubernetesInstance kubernetesInstance;
         try {
             ObjectMeta metadata = elasticAgentPod.getMetadata();
-            DateTime createdAt = DateTime.now().withZone(DateTimeZone.UTC);
+            Instant createdAt = Instant.now();
             if (StringUtils.isNotBlank(metadata.getCreationTimestamp())) {
-                createdAt = new DateTime(getSimpleDateFormat().parse(metadata.getCreationTimestamp())).withZone(DateTimeZone.UTC);
+                createdAt = Instant.parse(metadata.getCreationTimestamp());
             }
             String environment = metadata.getLabels().get(ENVIRONMENT_LABEL_KEY);
             Long jobId = Long.valueOf(metadata.getLabels().get(JOB_ID_LABEL_KEY));
             kubernetesInstance = new KubernetesInstance(createdAt, environment, metadata.getName(), metadata.getAnnotations(), jobId, PodState.fromPod(elasticAgentPod));
-        } catch (ParseException e) {
+        } catch (DateTimeParseException e) {
             throw new RuntimeException(e);
         }
         return kubernetesInstance;

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesInstanceFactory.java
@@ -62,7 +62,7 @@ public class KubernetesInstanceFactory {
             }
         }
         else {
-            if (Boolean.valueOf(request.properties().get(SPECIFIED_USING_POD_CONFIGURATION.getKey()))) {
+            if (Boolean.parseBoolean(request.properties().get(SPECIFIED_USING_POD_CONFIGURATION.getKey()))) {
                 return createUsingPodYaml(request, settings, client, pluginRequest);
             } else {
                 return createUsingProperties(request, settings, client, pluginRequest);
@@ -103,7 +103,7 @@ public class KubernetesInstanceFactory {
     }
 
     private void setGoCDMetadata(CreateAgentRequest request, PluginSettings settings, PluginRequest pluginRequest, Pod elasticAgentPod) {
-        elasticAgentPod.getMetadata().setCreationTimestamp(Instant.now().toString());
+        elasticAgentPod.getMetadata().setCreationTimestamp(KUBERNETES_POD_CREATION_TIME_FORMAT.format(Instant.now()));
 
         setContainerEnvVariables(elasticAgentPod, request, settings, pluginRequest);
         setAnnotations(elasticAgentPod, request);
@@ -158,7 +158,7 @@ public class KubernetesInstanceFactory {
             ObjectMeta metadata = elasticAgentPod.getMetadata();
             Instant createdAt = Instant.now();
             if (StringUtils.isNotBlank(metadata.getCreationTimestamp())) {
-                createdAt = Instant.parse(metadata.getCreationTimestamp());
+                createdAt = Constants.KUBERNETES_POD_CREATION_TIME_FORMAT.parse(metadata.getCreationTimestamp(), Instant::from);
             }
             String environment = metadata.getLabels().get(ENVIRONMENT_LABEL_KEY);
             Long jobId = Long.valueOf(metadata.getLabels().get(JOB_ID_LABEL_KEY));

--- a/src/main/java/cd/go/contrib/elasticagent/PluginSettings.java
+++ b/src/main/java/cd/go/contrib/elasticagent/PluginSettings.java
@@ -21,7 +21,8 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.StringUtils;
-import org.joda.time.Period;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 import static cd.go.contrib.elasticagent.utils.Util.IntTypeAdapter;
 
@@ -54,7 +55,7 @@ public class PluginSettings {
     @SerializedName("namespace")
     private String namespace;
 
-    private Period autoRegisterPeriod;
+    private Duration autoRegisterPeriod;
 
     public PluginSettings() {
     }
@@ -72,9 +73,9 @@ public class PluginSettings {
         return gson.fromJson(json, PluginSettings.class);
     }
 
-    public Period getAutoRegisterPeriod() {
+    public Duration getAutoRegisterPeriod() {
         if (this.autoRegisterPeriod == null) {
-            this.autoRegisterPeriod = new Period().withMinutes(getAutoRegisterTimeout());
+            this.autoRegisterPeriod = Duration.of(getAutoRegisterTimeout(), ChronoUnit.MINUTES);
         }
         return this.autoRegisterPeriod;
     }

--- a/src/main/java/cd/go/contrib/elasticagent/model/KubernetesPod.java
+++ b/src/main/java/cd/go/contrib/elasticagent/model/KubernetesPod.java
@@ -17,28 +17,27 @@
 package cd.go.contrib.elasticagent.model;
 
 import cd.go.contrib.elasticagent.Constants;
-import cd.go.contrib.elasticagent.utils.Util;
 import io.fabric8.kubernetes.api.model.Pod;
 
-import java.text.ParseException;
 import java.time.Instant;
 import java.util.Date;
 
 public class KubernetesPod {
     private final String podName;
-    private String nodeName;
+    private final String nodeName;
     private final String image;
     private final Date creationTimestamp;
     private final String podIP;
     private final String status;
-    private JobIdentifier jobIdentifier;
+    private final JobIdentifier jobIdentifier;
 
-    public KubernetesPod(Pod pod) throws ParseException {
+    public KubernetesPod(Pod pod) {
         jobIdentifier = JobIdentifier.fromJson(pod.getMetadata().getAnnotations().get(Constants.JOB_IDENTIFIER_LABEL_KEY));
         podName = pod.getMetadata().getName();
         image = pod.getSpec().getContainers().get(0).getImage();
         podIP = pod.getStatus().getPodIP();
-        creationTimestamp = Date.from(Instant.parse(pod.getMetadata().getCreationTimestamp()));
+        final CharSequence text = pod.getMetadata().getCreationTimestamp();
+        creationTimestamp = Date.from(Constants.KUBERNETES_POD_CREATION_TIME_FORMAT.parse(text, Instant::from));
         status = pod.getStatus().getPhase();
 
         nodeName = pod.getSpec().getNodeName();

--- a/src/main/java/cd/go/contrib/elasticagent/model/KubernetesPod.java
+++ b/src/main/java/cd/go/contrib/elasticagent/model/KubernetesPod.java
@@ -21,6 +21,7 @@ import cd.go.contrib.elasticagent.utils.Util;
 import io.fabric8.kubernetes.api.model.Pod;
 
 import java.text.ParseException;
+import java.time.Instant;
 import java.util.Date;
 
 public class KubernetesPod {
@@ -37,7 +38,7 @@ public class KubernetesPod {
         podName = pod.getMetadata().getName();
         image = pod.getSpec().getContainers().get(0).getImage();
         podIP = pod.getStatus().getPodIP();
-        creationTimestamp = Util.getSimpleDateFormat().parse(pod.getMetadata().getCreationTimestamp());
+        creationTimestamp = Date.from(Instant.parse(pod.getMetadata().getCreationTimestamp()));
         status = pod.getStatus().getPhase();
 
         nodeName = pod.getSpec().getNodeName();

--- a/src/main/java/cd/go/contrib/elasticagent/utils/Util.java
+++ b/src/main/java/cd/go/contrib/elasticagent/utils/Util.java
@@ -26,21 +26,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.Properties;
-
-import static cd.go.contrib.elasticagent.Constants.KUBERNETES_POD_CREATION_TIME_FORMAT;
 
 public class Util {
     public static final Gson GSON = new GsonBuilder()
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .excludeFieldsWithoutExposeAnnotation()
             .create();
-
-    public static DateTimeFormatter getSimpleDateFormat() {
-        return DateTimeFormatter.ofPattern(KUBERNETES_POD_CREATION_TIME_FORMAT).withZone(ZoneOffset.UTC);
-    }
 
     public static String readResource(String resourceFile) {
         return new String(readResourceBytes(resourceFile), StandardCharsets.UTF_8);

--- a/src/main/java/cd/go/contrib/elasticagent/utils/Util.java
+++ b/src/main/java/cd/go/contrib/elasticagent/utils/Util.java
@@ -26,9 +26,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Properties;
-import java.util.TimeZone;
 
 import static cd.go.contrib.elasticagent.Constants.KUBERNETES_POD_CREATION_TIME_FORMAT;
 
@@ -38,10 +38,8 @@ public class Util {
             .excludeFieldsWithoutExposeAnnotation()
             .create();
 
-    public static SimpleDateFormat getSimpleDateFormat() {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(KUBERNETES_POD_CREATION_TIME_FORMAT);
-        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return simpleDateFormat;
+    public static DateTimeFormatter getSimpleDateFormat() {
+        return DateTimeFormatter.ofPattern(KUBERNETES_POD_CREATION_TIME_FORMAT).withZone(ZoneOffset.UTC);
     }
 
     public static String readResource(String resourceFile) {

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesTest.java
@@ -24,13 +24,13 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -88,7 +88,7 @@ public class KubernetesAgentInstancesTest {
 
     @Test
     public void shouldCreateKubernetesPodUsingPodYamlAndCacheCreatedInstance() throws IOException {
-        KubernetesInstance kubernetesInstance = new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>(), 100L, PodState.Running);
+        KubernetesInstance kubernetesInstance = new KubernetesInstance(Instant.now(), "test", "test-agent", new HashMap<>(), 100L, PodState.Running);
         when(mockKubernetesInstanceFactory.create(mockCreateAgentRequest, mockPluginSettings, mockKubernetesClient, mockPluginRequest)).
                 thenReturn(kubernetesInstance);
 
@@ -101,7 +101,7 @@ public class KubernetesAgentInstancesTest {
 
     @Test
     public void shouldCreateKubernetesPodAndCacheCreatedInstance() throws IOException {
-        KubernetesInstance kubernetesInstance = new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>(), 100L, PodState.Running);
+        KubernetesInstance kubernetesInstance = new KubernetesInstance(Instant.now(), "test", "test-agent", new HashMap<>(), 100L, PodState.Running);
         when(mockKubernetesInstanceFactory.create(mockCreateAgentRequest, mockPluginSettings, mockKubernetesClient, mockPluginRequest)).
                 thenReturn(kubernetesInstance);
         testProperties.put("PodSpecType", "properties");
@@ -112,7 +112,7 @@ public class KubernetesAgentInstancesTest {
 
     @Test
     public void shouldCreateKubernetesPodFromFileAndCacheCreatedInstance() throws IOException {
-        KubernetesInstance kubernetesInstance = new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>(), 100L, PodState.Running);
+        KubernetesInstance kubernetesInstance = new KubernetesInstance(Instant.now(), "test", "test-agent", new HashMap<>(), 100L, PodState.Running);
         when(mockKubernetesInstanceFactory.create(mockCreateAgentRequest, mockPluginSettings, mockKubernetesClient, mockPluginRequest)).
                 thenReturn(kubernetesInstance);
         testProperties.put("PodSpecType", "remote");
@@ -123,7 +123,7 @@ public class KubernetesAgentInstancesTest {
 
     @Test
     public void shouldNotCreatePodWhenOutstandingRequestsExistForJobs() throws IOException {
-        KubernetesInstance kubernetesInstance = new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>(), 100L, PodState.Running);
+        KubernetesInstance kubernetesInstance = new KubernetesInstance(Instant.now(), "test", "test-agent", new HashMap<>(), 100L, PodState.Running);
         when(mockKubernetesInstanceFactory.create(mockCreateAgentRequest, mockPluginSettings, mockKubernetesClient, mockPluginRequest)).
                 thenReturn(kubernetesInstance);
         testProperties.put("PodSpecType", "properties");
@@ -157,7 +157,7 @@ public class KubernetesAgentInstancesTest {
         when(mockPluginSettings.getMaxPendingPods()).thenReturn(1);
 
         //pending kubernetes pod
-        KubernetesInstance kubernetesInstance = new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>(), 100L, PodState.Pending);
+        KubernetesInstance kubernetesInstance = new KubernetesInstance(Instant.now(), "test", "test-agent", new HashMap<>(), 100L, PodState.Pending);
         when(mockKubernetesInstanceFactory.create(mockCreateAgentRequest, mockPluginSettings, mockKubernetesClient, mockPluginRequest)).
                 thenReturn(kubernetesInstance);
         testProperties.put("PodSpecType", "properties");
@@ -190,7 +190,7 @@ public class KubernetesAgentInstancesTest {
     @Test
     public void shouldSyncPodsStateFromClusterBeforeCreatingPod() throws IOException {
         when(mockKubernetesInstanceFactory.create(mockCreateAgentRequest, mockPluginSettings, mockKubernetesClient, mockPluginRequest)).
-                thenReturn(new KubernetesInstance(new DateTime(), "test", "test-agent", new HashMap<>(), 100L, PodState.Running));
+                thenReturn(new KubernetesInstance(Instant.now(), "test", "test-agent", new HashMap<>(), 100L, PodState.Running));
 
         final KubernetesAgentInstances agentInstances = new KubernetesAgentInstances(factory, mockKubernetesInstanceFactory);
 

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesClientFactoryTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesClientFactoryTest.java
@@ -18,10 +18,11 @@ package cd.go.contrib.elasticagent;
 
 import com.google.gson.Gson;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,19 +60,19 @@ public class KubernetesClientFactoryTest {
     public void shouldReuseTheExistingClientIfNotTimeElapsed() {
         KubernetesClient client = factory.client(pluginSettings);
 
-        clock.set(new DateTime().plusMinutes(1));
+        clock.set(Instant.now().plus(1, ChronoUnit.MINUTES));
         KubernetesClient client2 = factory.client(pluginSettings);
         assertEquals(client, client2);
 
-        clock.set(new DateTime().plusMinutes(2));
+        clock.set(Instant.now().plus(2, ChronoUnit.MINUTES));
         KubernetesClient client3 = factory.client(pluginSettings);
         assertEquals(client, client3);
 
-        clock.set(new DateTime().plusMinutes(5));
+        clock.set(Instant.now().plus(5, ChronoUnit.MINUTES));
         KubernetesClient client4 = factory.client(pluginSettings);
         assertEquals(client, client4);
 
-        clock.set(new DateTime().plusMinutes(9));
+        clock.set(Instant.now().plus(9, ChronoUnit.MINUTES));
         KubernetesClient client5 = factory.client(pluginSettings);
         assertEquals(client, client5);
     }
@@ -80,12 +81,12 @@ public class KubernetesClientFactoryTest {
     public void shouldRecycleClientOnTimer() {
         KubernetesClient client = factory.client(pluginSettings);
 
-        clock.set(new DateTime().plusMinutes(9));
+        clock.set(Instant.now().plus(9, ChronoUnit.MINUTES));
 
         KubernetesClient client2 = factory.client(pluginSettings);
         assertEquals(client, client2);
 
-        clock.set(new DateTime().plusMinutes(11));
+        clock.set(Instant.now().plus(11, ChronoUnit.MINUTES));
 
         KubernetesClient clientAfterTimeElapse = factory.client(pluginSettings);
         assertNotEquals(client, clientAfterTimeElapse);
@@ -97,11 +98,11 @@ public class KubernetesClientFactoryTest {
 
         KubernetesClient client = factory.client(pluginSettings);
 
-        clock.set(new DateTime().plusMinutes(1));
+        clock.set(Instant.now().plus(1, ChronoUnit.MINUTES));
         KubernetesClient client2 = factory.client(pluginSettings);
         assertEquals(client, client2);
 
-        clock.set(new DateTime().plusMinutes(3));
+        clock.set(Instant.now().plus(3, ChronoUnit.MINUTES));
         KubernetesClient client3 = factory.client(pluginSettings);
         assertNotEquals(client, client3);
     }
@@ -112,15 +113,15 @@ public class KubernetesClientFactoryTest {
 
         KubernetesClient client = factory.client(pluginSettings);
 
-        clock.set(new DateTime().plusMinutes(1));
+        clock.set(Instant.now().plus(1, ChronoUnit.MINUTES));
         KubernetesClient client2 = factory.client(pluginSettings);
         assertEquals(client, client2);
 
-        clock.set(new DateTime().plusMinutes(9));
+        clock.set(Instant.now().plus(9, ChronoUnit.MINUTES));
         KubernetesClient client3 = factory.client(pluginSettings);
         assertEquals(client, client3);
 
-        clock.set(new DateTime().plusMinutes(11));
+        clock.set(Instant.now().plus(11, ChronoUnit.MINUTES));
         KubernetesClient client4 = factory.client(pluginSettings);
         assertNotEquals(client, client4);
     }

--- a/src/test/java/cd/go/contrib/elasticagent/builders/PluginStatusReportViewBuilderTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/builders/PluginStatusReportViewBuilderTest.java
@@ -35,28 +35,28 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class PluginStatusReportViewBuilderTest {
-  @Test
-  public void shouldBuildStatusReportHtmlWithAgentStatusReportLink() throws IOException, TemplateException {
-    KubernetesPod pod = mock(KubernetesPod.class);
-    when(pod.getJobIdentifier()).thenReturn(new JobIdentifier(3243546575676657L));
-    when(pod.getCreationTimestamp()).thenReturn(new Date());
+    @Test
+    public void shouldBuildStatusReportHtmlWithAgentStatusReportLink() throws IOException, TemplateException {
+        KubernetesPod pod = mock(KubernetesPod.class);
+        when(pod.getJobIdentifier()).thenReturn(new JobIdentifier(3243546575676657L));
+        when(pod.getCreationTimestamp()).thenReturn(new Date());
 
-    KubernetesNode node = mock(KubernetesNode.class);
-    when(node.getPods()).thenReturn(singletonList(pod));
+        KubernetesNode node = mock(KubernetesNode.class);
+        when(node.getPods()).thenReturn(singletonList(pod));
 
-    KubernetesCluster cluster = mock(KubernetesCluster.class);
-    when(cluster.getNodes()).thenReturn(singletonList(node));
-    when(cluster.getPluginId()).thenReturn("cd.go.contrib.elastic.agent.kubernetes");
-    PluginStatusReportViewBuilder builder = PluginStatusReportViewBuilder.instance();
+        KubernetesCluster cluster = mock(KubernetesCluster.class);
+        when(cluster.getNodes()).thenReturn(singletonList(node));
+        when(cluster.getPluginId()).thenReturn("cd.go.contrib.elastic.agent.kubernetes");
+        PluginStatusReportViewBuilder builder = PluginStatusReportViewBuilder.instance();
 
-    String build = builder.build(builder.getTemplate("status-report.template.ftlh"), cluster);
+        String build = builder.build(builder.getTemplate("status-report.template.ftlh"), cluster);
 
-    Document document = Jsoup.parse(build);
+        Document document = Jsoup.parse(build);
 
-    Element link = document.selectFirst("tbody tr td a");
-    System.out.println(link);
+        Element link = document.selectFirst("tbody tr td a");
+        System.out.println(link);
 
-    assertThat(link.attr("href")).isEqualTo("/go/admin/status_reports/cd.go.contrib.elastic.agent.kubernetes/agent/?job_id=3243546575676657");
-  }
+        assertThat(link.attr("href")).isEqualTo("/go/admin/status_reports/cd.go.contrib.elastic.agent.kubernetes/agent/?job_id=3243546575676657");
+    }
 
 }

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
@@ -24,13 +24,15 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
 
+import java.time.Instant;
 import java.util.*;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
 
 import static cd.go.contrib.elasticagent.Constants.JOB_ID_LABEL_KEY;
 import static cd.go.contrib.elasticagent.utils.Util.getSimpleDateFormat;
@@ -66,7 +68,7 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         when(podResource.get()).thenReturn(mockedPod);
 
         objectMetadata = new ObjectMeta();
-        objectMetadata.setCreationTimestamp(getSimpleDateFormat().format(new Date()));
+        objectMetadata.setCreationTimestamp(getSimpleDateFormat().format(Instant.now()));
 
         when(mockedPod.getMetadata()).thenReturn(objectMetadata);
 
@@ -88,9 +90,9 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         Agent agent2 = new Agent(agentId2, Agent.AgentState.Idle, Agent.BuildState.Idle, Agent.ConfigState.Enabled); //idle just created
         Agent agent3 = new Agent(agentId3, Agent.AgentState.Building, Agent.BuildState.Building, Agent.ConfigState.Enabled); //running time elapsed
 
-        KubernetesInstance k8sPodForAgent1 = new KubernetesInstance(new DateTime().minusMinutes(100), null, agentId1, Collections.emptyMap(), 1L, PodState.Running);
-        KubernetesInstance k8sPodForAgent2 = new KubernetesInstance(new DateTime(), null, agentId2, Collections.emptyMap(), 2L, PodState.Running);
-        KubernetesInstance k8sPodForAgent3 = new KubernetesInstance(new DateTime().minusMinutes(100), null, agentId3, Collections.emptyMap(), 3L, PodState.Running);
+        KubernetesInstance k8sPodForAgent1 = new KubernetesInstance(Instant.now().minus(100, MINUTES), null, agentId1, Collections.emptyMap(), 1L, PodState.Running);
+        KubernetesInstance k8sPodForAgent2 = new KubernetesInstance(Instant.now(), null, agentId2, Collections.emptyMap(), 2L, PodState.Running);
+        KubernetesInstance k8sPodForAgent3 = new KubernetesInstance(Instant.now().minus(100, MINUTES), null, agentId3, Collections.emptyMap(), 3L, PodState.Running);
 
         final Agents allAgentsInitially = new Agents(Arrays.asList(agent1, agent2, agent3));
         final Agents allAgentsAfterDisablingIdleAgents = new Agents(Arrays.asList(agent1AfterDisabling, agent2, agent3));
@@ -142,13 +144,13 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         Agent agent5 = new Agent(agentId5, Agent.AgentState.Idle, Agent.BuildState.Idle, Agent.ConfigState.Enabled); //idle just created
         Agent agent6 = new Agent(agentId6, Agent.AgentState.Building, Agent.BuildState.Building, Agent.ConfigState.Enabled); //running time elapsed
 
-        KubernetesInstance k8sPodForAgent1 = new KubernetesInstance(new DateTime().minusMinutes(100), null, agentId1, Collections.emptyMap(), 1L, PodState.Running);
-        KubernetesInstance k8sPodForAgent2 = new KubernetesInstance(new DateTime(), null, agentId2, Collections.emptyMap(), 2L, PodState.Running);
-        KubernetesInstance k8sPodForAgent3 = new KubernetesInstance(new DateTime().minusMinutes(100), null, agentId3, Collections.emptyMap(), 3L, PodState.Running);
+        KubernetesInstance k8sPodForAgent1 = new KubernetesInstance(Instant.now().minus(100, MINUTES), null, agentId1, Collections.emptyMap(), 1L, PodState.Running);
+        KubernetesInstance k8sPodForAgent2 = new KubernetesInstance(Instant.now(), null, agentId2, Collections.emptyMap(), 2L, PodState.Running);
+        KubernetesInstance k8sPodForAgent3 = new KubernetesInstance(Instant.now().minus(100, MINUTES), null, agentId3, Collections.emptyMap(), 3L, PodState.Running);
 
-        KubernetesInstance k8sPodForAgent4 = new KubernetesInstance(new DateTime().minusMinutes(100), null, agentId4, Collections.emptyMap(), 1L, PodState.Running);
-        KubernetesInstance k8sPodForAgent5 = new KubernetesInstance(new DateTime(), null, agentId5, Collections.emptyMap(), 2L, PodState.Running);
-        KubernetesInstance k8sPodForAgent6 = new KubernetesInstance(new DateTime().minusMinutes(100), null, agentId6, Collections.emptyMap(), 3L, PodState.Running);
+        KubernetesInstance k8sPodForAgent4 = new KubernetesInstance(Instant.now().minus(100, MINUTES), null, agentId4, Collections.emptyMap(), 1L, PodState.Running);
+        KubernetesInstance k8sPodForAgent5 = new KubernetesInstance(Instant.now(), null, agentId5, Collections.emptyMap(), 2L, PodState.Running);
+        KubernetesInstance k8sPodForAgent6 = new KubernetesInstance(Instant.now().minus(100, MINUTES), null, agentId6, Collections.emptyMap(), 3L, PodState.Running);
 
         final Agents allAgentsInitially = new Agents(Arrays.asList(agent1, agent2, agent3, agent4, agent5, agent6));
         final Agents allAgentsAfterDisablingIdleAgentsFromCluster1 = new Agents(Arrays.asList(agent1AfterDisabling, agent2, agent3, agent4, agent5, agent6));
@@ -204,14 +206,14 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         objectMetadata = new ObjectMeta();
         objectMetadata.setLabels(Collections.singletonMap(JOB_ID_LABEL_KEY, "20"));
         objectMetadata.setName(unregisteredAgentId1);
-        objectMetadata.setCreationTimestamp(getSimpleDateFormat().format(new Date(time - (20 * 60000))));
+        objectMetadata.setCreationTimestamp(getSimpleDateFormat().format(Instant.now().minus(20, MINUTES)));
 
         when(mockedPod.getMetadata()).thenReturn(objectMetadata);
 
         ClusterProfileProperties clusterProfilePropertiesForCluster1 = new ClusterProfileProperties("https://localhost:8154/go", null, null);
 
-        KubernetesInstance k8sUnregisteredCluster1Pod1 = new KubernetesInstance(new DateTime().minusMinutes(100), null, unregisteredAgentId1, Collections.emptyMap(), 3L, PodState.Running);
-        KubernetesInstance k8sUnregisteredCluster1Pod2 = new KubernetesInstance(new DateTime(), null, unregisteredAgentId2, Collections.emptyMap(), 3L, PodState.Running);
+        KubernetesInstance k8sUnregisteredCluster1Pod1 = new KubernetesInstance(Instant.now().minus(100, MINUTES), null, unregisteredAgentId1, Collections.emptyMap(), 3L, PodState.Running);
+        KubernetesInstance k8sUnregisteredCluster1Pod2 = new KubernetesInstance(Instant.now(), null, unregisteredAgentId2, Collections.emptyMap(), 3L, PodState.Running);
 
         final Agents allAgentsInitially = new Agents();
 

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
@@ -32,9 +32,8 @@ import org.mockito.stubbing.Answer;
 import java.time.Instant;
 import java.util.*;
 
-import static java.time.temporal.ChronoUnit.MINUTES;
-
 import static cd.go.contrib.elasticagent.Constants.JOB_ID_LABEL_KEY;
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -67,7 +66,7 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         when(podResource.get()).thenReturn(mockedPod);
 
         objectMetadata = new ObjectMeta();
-        objectMetadata.setCreationTimestamp(Instant.now().toString());
+        objectMetadata.setCreationTimestamp(Constants.KUBERNETES_POD_CREATION_TIME_FORMAT.format(Instant.now()));
 
         when(mockedPod.getMetadata()).thenReturn(objectMetadata);
 
@@ -205,7 +204,7 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         objectMetadata = new ObjectMeta();
         objectMetadata.setLabels(Collections.singletonMap(JOB_ID_LABEL_KEY, "20"));
         objectMetadata.setName(unregisteredAgentId1);
-        objectMetadata.setCreationTimestamp(Instant.now().minus(20, MINUTES).toString());
+        objectMetadata.setCreationTimestamp(Constants.KUBERNETES_POD_CREATION_TIME_FORMAT.format(Instant.now().minus(20, MINUTES)));
 
         when(mockedPod.getMetadata()).thenReturn(objectMetadata);
 

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
@@ -35,7 +35,6 @@ import java.util.*;
 import static java.time.temporal.ChronoUnit.MINUTES;
 
 import static cd.go.contrib.elasticagent.Constants.JOB_ID_LABEL_KEY;
-import static cd.go.contrib.elasticagent.utils.Util.getSimpleDateFormat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -206,7 +205,7 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         objectMetadata = new ObjectMeta();
         objectMetadata.setLabels(Collections.singletonMap(JOB_ID_LABEL_KEY, "20"));
         objectMetadata.setName(unregisteredAgentId1);
-        objectMetadata.setCreationTimestamp(getSimpleDateFormat().format(Instant.now().minus(20, MINUTES)));
+        objectMetadata.setCreationTimestamp(Instant.now().minus(20, MINUTES).toString());
 
         when(mockedPod.getMetadata()).thenReturn(objectMetadata);
 

--- a/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/ServerPingRequestExecutorTest.java
@@ -68,7 +68,7 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         when(podResource.get()).thenReturn(mockedPod);
 
         objectMetadata = new ObjectMeta();
-        objectMetadata.setCreationTimestamp(getSimpleDateFormat().format(Instant.now()));
+        objectMetadata.setCreationTimestamp(Instant.now().toString());
 
         when(mockedPod.getMetadata()).thenReturn(objectMetadata);
 


### PR DESCRIPTION
## Description

From the [Joda time project's website](https://www.joda.org/joda-time/), users on Java 8 or later are asked to migrate to `java.time`:

> Note that from Java SE 8 onwards, users are asked to migrate to java.time (JSR-310) - a core part of the JDK which replaces this project.

## Changes

This PR replaces usage of joda-time classes with the Java standard library, and removes joda-time from the dependencies. These changes are fairly mechanical, as `org.joda.time.DateTime` corresponds closely to `java.time.Instant`, `org.joda.time.Period` corresponds closely to `java.time.Duration`, and so on.

I also replaced `java.util.Date` with `java.time.Instant` opportunistically in a few places. One place where that's a little less trivial is in the freemarker templates, as freemarker doesn't support `java.time` itself and requires a third party plugin. I decided to leave that out of this PR but could open another PR for that later if you're interested. 🙂 

## Testing

I've run unit tests locally with `./gradlew test`.

Also spun up a local GoCD server, and checked places where these timestamps are rendered in the UI.

### Cluster status report page
Created At timestamp:

![gocd_cluster_status_report png](https://user-images.githubusercontent.com/25603218/222876620-8d33c70a-0c7c-45bc-846d-7ce63cf37f63.PNG)

### Agent status report page
Creation Timestamp and Start Timestamp:

![GoCD agent status report](https://user-images.githubusercontent.com/25603218/222876636-58b1350c-eb99-4c0f-84e9-06a54af6aee3.PNG)

### Job console logs
Timestamps in the "Received request to create a pod" message:

![GoCD job logs](https://user-images.githubusercontent.com/25603218/222876645-fdaa4919-c597-4b87-a051-598eddf94010.PNG)