### PR TITLE
adding cluster timeout config

### DIFF
--- a/docs/configure_cluster_profile.md
+++ b/docs/configure_cluster_profile.md
@@ -13,25 +13,27 @@
 
 1. Optionally specify `Agent auto-register timeout (in minutes)`. This defaults to 10 (minutes) if not provided.
 
-1. Optionally Specify `Maximum pending pods`. This defaults to 10 (pods) if not provided.
+2. Optionally specify `The cluster request timeout`. This defaults to 10000 (milliseconds) if not provided.
 
-1. Specify `Cluster URL`.
+3. Optionally Specify `Maximum pending pods`. This defaults to 10 (pods) if not provided.
 
-1. Optionally specify `Namespace`. If not provided, the plugin will launch GoCD
+4. Specify `Cluster URL`.
+
+5. Optionally specify `Namespace`. If not provided, the plugin will launch GoCD
    agent pods in the default Kubernetes namespace. Note: If you have multiple
    GoCD servers with cluster profiles pointing to the same Kubernetes cluster,
    make sure that the namespace used by each GoCD server is different.
    Otherwise, the plugin of one GoCD server will end up terminating pods
    started by the plugin in the other GoCD servers.
 
-1. Specify `Security token`. This should be a Kubernetes API token with the
+6. Specify `Security token`. This should be a Kubernetes API token with the
    following permissions:
 
-   | Resource       | Actions     |
-   | -------------- | ----------- |
-   | nodes          | list        |
-   | events         | list        |
-   | pods, pods/log | *           |
+   | Resource       | Actions |
+   | -------------- | ------- |
+   | nodes          | list    |
+   | events         | list    |
+   | pods, pods/log | *       |
 
    If the plugin is using a non-default namespace, then the pods and pods/log permissions
    can be limited to that namespace (using a role + role binding), and the plugin
@@ -42,7 +44,7 @@
    If you are comfortable with cluster-wide permissions you can refer to the [example within the GoCD official helm
    chart](https://github.com/gocd/helm-chart/blob/master/gocd/templates/gocd-cluster-role.yaml).
 
-1. Specify `Cluster CA certificate data`. This should be the base-64-encoded certificate
+7. Specify `Cluster CA certificate data`. This should be the base-64-encoded certificate
    of the Kubernetes API server. It can be omitted in the rare case that the Kubernetes API
    is configured to serve plain HTTP.
 

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesClientFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesClientFactory.java
@@ -76,6 +76,7 @@ public class KubernetesClientFactory {
     private KubernetesClient createClientFor(PluginSettings pluginSettings) {
         final ConfigBuilder configBuilder = new ConfigBuilder()
                 .withAutoConfigure(false)
+                .withRequestTimeout(pluginSettings.getClusterRequestTimeout())
                 .withOauthToken(pluginSettings.getSecurityToken())
                 .withMasterUrl(pluginSettings.getClusterUrl())
                 .withCaCertData(pluginSettings.getCaCertData())

--- a/src/main/java/cd/go/contrib/elasticagent/KubernetesPlugin.java
+++ b/src/main/java/cd/go/contrib/elasticagent/KubernetesPlugin.java
@@ -113,6 +113,7 @@ public class KubernetesPlugin implements GoPlugin {
             }
         } catch (Exception e) {
             LOG.error("Failed to handle request " + request.requestName(), e);
+
             return DefaultGoPluginApiResponse.error("Failed to handle request " + request.requestName());
         }
     }

--- a/src/main/java/cd/go/contrib/elasticagent/PluginSettings.java
+++ b/src/main/java/cd/go/contrib/elasticagent/PluginSettings.java
@@ -41,6 +41,10 @@ public class PluginSettings {
     private String maxPendingPods;
 
     @Expose
+    @SerializedName("cluster_request_timeout")
+    private String clusterRequestTimeout;
+
+    @Expose
     @SerializedName("kubernetes_cluster_url")
     private String clusterUrl;
 
@@ -91,6 +95,13 @@ public class PluginSettings {
         return getOrDefault(maximumPendingPodsInt, 10);
     }
 
+    public Integer getClusterRequestTimeout() {
+        Integer maximumPendingPodsInt = !isBlank(this.clusterRequestTimeout)
+                ? Integer.valueOf(this.clusterRequestTimeout)
+                : null;
+        return getOrDefault(maximumPendingPodsInt, 10000);
+    }
+
     public String getGoServerUrl() {
         return goServerUrl;
     }
@@ -130,12 +141,16 @@ public class PluginSettings {
 
         PluginSettings that = (PluginSettings) o;
 
-        if (goServerUrl != null ? !goServerUrl.equals(that.goServerUrl) : that.goServerUrl != null) return false;
+        if (goServerUrl != null ? !goServerUrl.equals(that.goServerUrl) : that.goServerUrl != null)
+            return false;
         if (autoRegisterTimeout != null ? !autoRegisterTimeout.equals(that.autoRegisterTimeout) : that.autoRegisterTimeout != null)
             return false;
         if (maxPendingPods != null ? !maxPendingPods.equals(that.maxPendingPods) : that.maxPendingPods != null)
             return false;
-        if (clusterUrl != null ? !clusterUrl.equals(that.clusterUrl) : that.clusterUrl != null) return false;
+        if (clusterRequestTimeout != null ? !clusterRequestTimeout.equals(that.clusterRequestTimeout) : that.clusterRequestTimeout != null)
+            return false;
+        if (clusterUrl != null ? !clusterUrl.equals(that.clusterUrl) : that.clusterUrl != null)
+            return false;
         if (securityToken != null ? !securityToken.equals(that.securityToken) : that.securityToken != null)
             return false;
         if (clusterCACertData != null ? !clusterCACertData.equals(that.clusterCACertData) : that.clusterCACertData != null)
@@ -148,6 +163,7 @@ public class PluginSettings {
         int result = goServerUrl != null ? goServerUrl.hashCode() : 0;
         result = 31 * result + (autoRegisterTimeout != null ? autoRegisterTimeout.hashCode() : 0);
         result = 31 * result + (maxPendingPods != null ? maxPendingPods.hashCode() : 0);
+        result = 31 * result + (clusterRequestTimeout != null ? clusterRequestTimeout.hashCode() : 0);
         result = 31 * result + (clusterUrl != null ? clusterUrl.hashCode() : 0);
         result = 31 * result + (securityToken != null ? securityToken.hashCode() : 0);
         result = 31 * result + (clusterCACertData != null ? clusterCACertData.hashCode() : 0);
@@ -161,6 +177,7 @@ public class PluginSettings {
                 "goServerUrl='" + goServerUrl + '\'' +
                 ", autoRegisterTimeout=" + autoRegisterTimeout +
                 ", maxPendingPods=" + maxPendingPods +
+                ", clusterRequestTimeout=" + clusterRequestTimeout +
                 ", clusterUrl='" + clusterUrl + '\'' +
                 ", securityToken='" + securityToken + '\'' +
                 ", clusterCACertData='" + clusterCACertData + '\'' +

--- a/src/main/java/cd/go/contrib/elasticagent/executors/GetClusterProfileMetadataExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagent/executors/GetClusterProfileMetadataExecutor.java
@@ -33,6 +33,7 @@ public class GetClusterProfileMetadataExecutor implements RequestExecutor {
     public static final Metadata GO_SERVER_URL = new GoServerURLMetadata();
     public static final Metadata AUTO_REGISTER_TIMEOUT = new Metadata("auto_register_timeout", false, false);
     public static final Metadata MAX_PENDING_PODS = new Metadata("pending_pods_count", false, false);
+    public static final Metadata CLUSTER_REQUEST_TIMEOUT = new Metadata("cluster_request_timeout", false, false);
     public static final Metadata CLUSTER_URL = new Metadata("kubernetes_cluster_url", true, false);
     public static final Metadata NAMESPACE = new Metadata("namespace", false, false);
     public static final Metadata SECURITY_TOKEN = new Metadata("security_token", true, true);
@@ -44,6 +45,7 @@ public class GetClusterProfileMetadataExecutor implements RequestExecutor {
         FIELDS.add(GO_SERVER_URL);
         FIELDS.add(AUTO_REGISTER_TIMEOUT);
         FIELDS.add(MAX_PENDING_PODS);
+        FIELDS.add(CLUSTER_REQUEST_TIMEOUT);
         FIELDS.add(CLUSTER_URL);
         FIELDS.add(NAMESPACE);
         FIELDS.add(SECURITY_TOKEN);

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -85,6 +85,13 @@
 	</div>
 
 	<div class="row">
+		<label>The cluster request timeout(in milliseconds)</label>
+		<input type="text" ng-model="cluster_request_timeout" ng-required="true"/>
+		<span class="form_error" ng-show="GOINPUTNAME[cluster_request_timeout].$error.server">{{GOINPUTNAME[cluster_request_timeout].$error.server}}</span>
+		<label class="form-help-content">Defaults to <code>10000 milliseconds</code>.</label>
+	</div>
+
+	<div class="row">
 		<label>Maximum pending pods</label>
 		<input type="text" ng-model="pending_pods_count" ng-required="true"/>
 		<span class="form_error" ng-show="GOINPUTNAME[pending_pods_count].$error.server">{{GOINPUTNAME[pending_pods_count].$error.server}}</span>

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesAgentInstancesTest.java
@@ -38,6 +38,7 @@ import java.util.Map;
 
 import static cd.go.contrib.elasticagent.Constants.JOB_ID_LABEL_KEY;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -77,6 +78,7 @@ public class KubernetesAgentInstancesTest {
         testProperties = new HashMap<>();
         when(mockCreateAgentRequest.properties()).thenReturn(testProperties);
         when(mockPluginSettings.getMaxPendingPods()).thenReturn(10);
+        when(mockPluginSettings.getClusterRequestTimeout()).thenReturn(10000);
         when(factory.client(mockPluginSettings)).thenReturn(mockKubernetesClient);
         JobIdentifier jobId = new JobIdentifier("test", 1L, "Test pipeline", "test name", "1", "test job", 100L);
         when(mockCreateAgentRequest.jobIdentifier()).thenReturn(jobId);
@@ -117,7 +119,8 @@ public class KubernetesAgentInstancesTest {
                 thenReturn(kubernetesInstance);
         testProperties.put("PodSpecType", "remote");
         KubernetesAgentInstances agentInstances = new KubernetesAgentInstances(factory, mockKubernetesInstanceFactory);
-        KubernetesInstance instance = agentInstances.create(mockCreateAgentRequest, mockPluginSettings, mockPluginRequest, consoleLogAppender);
+        KubernetesInstance instance = agentInstances.create(mockCreateAgentRequest, mockPluginSettings,
+                mockPluginRequest, consoleLogAppender);
         assertTrue(agentInstances.instanceExists(instance));
     }
 

--- a/src/test/java/cd/go/contrib/elasticagent/KubernetesClientFactoryTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/KubernetesClientFactoryTest.java
@@ -42,6 +42,7 @@ public class KubernetesClientFactoryTest {
         pluginSettingsMap.put("go_server_url", "https://foo.go.cd/go");
         pluginSettingsMap.put("auto_register_timeout", "13");
         pluginSettingsMap.put("pending_pods_count", "14");
+        pluginSettingsMap.put("cluster_request_timeout", "10000");
         pluginSettingsMap.put("kubernetes_cluster_url", "https://cloud.example.com");
         pluginSettingsMap.put("security_token", "foo-token");
         pluginSettingsMap.put("namespace", "gocd");

--- a/src/test/java/cd/go/contrib/elasticagent/PluginSettingsTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/PluginSettingsTest.java
@@ -33,6 +33,7 @@ public class PluginSettingsTest {
         pluginSettingsMap.put("go_server_url", "https://foo.go.cd/go");
         pluginSettingsMap.put("auto_register_timeout", "13");
         pluginSettingsMap.put("pending_pods_count", "14");
+        pluginSettingsMap.put("cluster_request_timeout", "60000");
         pluginSettingsMap.put("kubernetes_cluster_url", "https://cloud.example.com");
         pluginSettingsMap.put("security_token", "foo-token");
         pluginSettingsMap.put("kubernetes_cluster_ca_cert", "foo-ca-certs");
@@ -43,6 +44,7 @@ public class PluginSettingsTest {
         assertThat(pluginSettings.getGoServerUrl()).isEqualTo("https://foo.go.cd/go");
         assertThat(pluginSettings.getAutoRegisterTimeout()).isEqualTo(13);
         assertThat(pluginSettings.getMaxPendingPods()).isEqualTo(14);
+        assertThat(pluginSettings.getClusterRequestTimeout()).isEqualTo(60000);
         assertThat(pluginSettings.getClusterUrl()).isEqualTo("https://cloud.example.com");
         assertThat(pluginSettings.getCaCertData()).isEqualTo("foo-ca-certs");
         assertThat(pluginSettings.getSecurityToken()).isEqualTo("foo-token");
@@ -56,6 +58,7 @@ public class PluginSettingsTest {
         pluginSettingsMap.put("go_server_url", "https://foo.go.cd/go");
         pluginSettingsMap.put("auto_register_timeout", "");
         pluginSettingsMap.put("pending_pods_count", null);
+        pluginSettingsMap.put("cluster_request_timeout", null);
         pluginSettingsMap.put("kubernetes_cluster_url", "https://cloud.example.com");
         pluginSettingsMap.put("security_token", "foo-token");
         pluginSettingsMap.put("kubernetes_cluster_ca_cert", "foo-ca-certs");
@@ -66,6 +69,7 @@ public class PluginSettingsTest {
         assertThat(pluginSettings.getGoServerUrl()).isEqualTo("https://foo.go.cd/go");
         assertThat(pluginSettings.getAutoRegisterTimeout()).isEqualTo(10);
         assertThat(pluginSettings.getMaxPendingPods()).isEqualTo(10);
+        assertThat(pluginSettings.getClusterRequestTimeout()).isEqualTo(10000);
         assertThat(pluginSettings.getClusterUrl()).isEqualTo("https://cloud.example.com");
         assertThat(pluginSettings.getCaCertData()).isEqualTo("foo-ca-certs");
         assertThat(pluginSettings.getSecurityToken()).isEqualTo("foo-token");
@@ -79,6 +83,7 @@ public class PluginSettingsTest {
         assertNull(pluginSettings.getGoServerUrl());
         assertThat(pluginSettings.getAutoRegisterTimeout()).isEqualTo(10);
         assertThat(pluginSettings.getMaxPendingPods()).isEqualTo(10);
+        assertThat(pluginSettings.getClusterRequestTimeout()).isEqualTo(10000);
         assertThat(pluginSettings.getNamespace()).isEqualTo("default");
         assertNull(pluginSettings.getClusterUrl());
         assertNull(pluginSettings.getCaCertData());

--- a/src/test/java/cd/go/contrib/elasticagent/executors/GetClusterProfileMetadataExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/GetClusterProfileMetadataExecutorTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
 public class GetClusterProfileMetadataExecutorTest {
     @Test
     public void shouldSerializeAllFields() throws Exception {
@@ -60,6 +59,13 @@ public class GetClusterProfileMetadataExecutorTest {
                 "  },\n" +
                 "  {\n" +
                 "    \"key\": \"pending_pods_count\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": false,\n" +
+                "      \"secure\": false\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"key\": \"cluster_request_timeout\",\n" +
                 "    \"metadata\": {\n" +
                 "      \"required\": false,\n" +
                 "      \"secure\": false\n" +

--- a/src/test/java/cd/go/contrib/elasticagent/executors/GetClusterProfileViewRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/executors/GetClusterProfileViewRequestExecutorTest.java
@@ -30,7 +30,6 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 public class GetClusterProfileViewRequestExecutorTest {
     @Test
     public void shouldRenderTheTemplateInJSON() throws Exception {
@@ -57,6 +56,6 @@ public class GetClusterProfileViewRequestExecutorTest {
         }
 
         final Elements inputs = document.select("textarea,input[type=text],select,input[type=checkbox]");
-        assertThat(inputs).hasSize(GetProfileMetadataExecutor.FIELDS.size() - 3); // do not include SPECIFIED_USING_POD_CONFIGURATION, POD_SPEC_TYPE, REMOTE_FILE_TYPE key
+        assertThat(inputs).hasSize(GetClusterProfileMetadataExecutor.FIELDS.size());
     }
 }


### PR DESCRIPTION
This implements a configuration for setting timeouts for requests to the k8s cluster. GKE has been consistently outside the default timeout threshold for us, so we need a way to set `.withRequestTimeout(pluginSettings.getClusterRequestTimeout())` on the Kubernetes Client.

![Screenshot 2023-11-28 at 11 32 40 PM](https://github.com/gocd/kubernetes-elastic-agents/assets/1578246/af3fbf52-a1f2-49a4-a15a-1092a99c95dd)
