### PR TITLE
Treat blank CA Cert data as not set

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagent/PluginSettings.java
+++ b/src/main/java/cd/go/contrib/elasticagent/PluginSettings.java
@@ -108,7 +108,7 @@ public class PluginSettings {
     }
 
     public String getCaCertData() {
-        return clusterCACertData;
+        return isBlank(clusterCACertData) ? null : clusterCACertData;
     }
 
     public Integer getClusterRequestTimeout() {

--- a/src/test/java/cd/go/contrib/elasticagent/PluginSettingsTest.java
+++ b/src/test/java/cd/go/contrib/elasticagent/PluginSettingsTest.java
@@ -98,4 +98,14 @@ public class PluginSettingsTest {
 
         assertThat(pluginSettings.getNamespace()).isEqualTo("default");
     }
+
+    @Test
+    public void shouldConsiderBlankCertAsNull() {
+        final Map<String, Object> pluginSettingsMap = new HashMap<>();
+        pluginSettingsMap.put("kubernetes_cluster_ca_cert", "   ");
+
+        PluginSettings pluginSettings = PluginSettings.fromJSON(new Gson().toJson(pluginSettingsMap));
+
+        assertThat(pluginSettings.getCaCertData()).isNull();
+    }
 }


### PR DESCRIPTION
The Kubernetes Client appears to treat these differently. If using a null cert it appears it willm either fall back to trusting all certs or (more likely) using an auto-configured cert it finds within the pod from the service account auto mount files.

Currently there are weird inconsistencies as after you edit the config or restart the server it can set an empty string which starts causing validation failures talking to the API.